### PR TITLE
fix(server): normalized request should implement the `text` method

### DIFF
--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -121,6 +121,8 @@ export function normalizeNodeRequest(nodeRequest: NodeRequest, RequestCtor: type
         switch (prop) {
           case 'json':
             return async () => maybeParsedBody;
+          case 'text':
+            return async () => JSON.stringify(maybeParsedBody);
           default:
             return Reflect.get(target, prop, receiver);
         }


### PR DESCRIPTION
Request in Fetch has a `text` method which should be respected even if the body was parsed previously.

Currently `.json()` returns an object but `.text()` an empty string - they should be coherent. 