### PR TITLE
Stabilise and improve tests

### DIFF
--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -41,8 +41,8 @@
 
   ```ts
   createServerAdapter(req => {
-    return new Response(`I got ${req.url}`);
-  });
+    return new Response(`I got ${req.url}`)
+  })
   ```
 
   Breaking Changes;

--- a/packages/server/test/node.spec.ts
+++ b/packages/server/test/node.spec.ts
@@ -1,34 +1,18 @@
 import { createServerAdapter } from '@whatwg-node/server';
-import { createServer, Server } from 'http';
 import { fetch, Response } from '@whatwg-node/fetch';
+import { startTServer } from './tserver';
 
 describe('Node Specific Cases', () => {
-  let port = 9876;
-  let server: Server | undefined;
-  afterEach(done => {
-    if (server) {
-      server.close(err => {
-        if (err) {
-          throw err;
-        }
-        server = undefined;
-        done();
-      });
-    } else {
-      done();
-    }
-    port = Math.floor(Math.random() * 1000) + 9800;
-  });
   it('should handle empty responses', async () => {
     const serverAdapter = createServerAdapter(() => {
       return undefined as any;
     });
-    server = createServer(serverAdapter);
-    await new Promise<void>(resolve => server!.listen(port, resolve));
-    const response = await fetch(`http://localhost:${port}`);
+    const { url } = startTServer(serverAdapter);
+    const response = await fetch(url);
     await response.text();
     expect(response.status).toBe(404);
   });
+
   it('should handle waitUntil properly', async () => {
     let flag = false;
     const serverAdapter = createServerAdapter((_request, { waitUntil }) => {
@@ -43,9 +27,8 @@ describe('Node Specific Cases', () => {
         })
       );
     });
-    server = createServer(serverAdapter);
-    await new Promise<void>(resolve => server!.listen(port, resolve));
-    const response$ = fetch(`http://localhost:${port}`);
+    const { url } = startTServer(serverAdapter);
+    const response$ = fetch(url);
     expect(flag).toBe(false);
     const response = await response$;
     await response.text();

--- a/packages/server/test/tserver.ts
+++ b/packages/server/test/tserver.ts
@@ -1,0 +1,43 @@
+import { createServer, RequestListener, Server } from 'http';
+import { AddressInfo, Socket } from 'net';
+
+const serverLeftovers: (() => Promise<void>)[] = [];
+afterAll(async () => {
+  while (serverLeftovers.length > 0) {
+    await serverLeftovers.pop()?.();
+  }
+});
+
+/**
+ * Starts a disposable Node test server that destroys connected sockets on dispose and then stops.
+ *
+ * In case you forgot to dispose yourself, the server will be auto-disposed after all tests complete.
+ */
+export function startTServer(listener?: RequestListener): {
+  server: Server;
+  url: string;
+  dispose: () => Promise<void>;
+} {
+  const server = createServer(listener);
+
+  const sockets = new Set<Socket>();
+  server.on('connection', socket => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
+
+  const dispose = async () => {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  };
+  serverLeftovers.push(dispose);
+
+  server.listen(0);
+
+  const { port } = server.address() as AddressInfo;
+  const url = `http://localhost:${port}`;
+
+  return { server, url, dispose };
+}


### PR DESCRIPTION
Use "tserver" that gets properly disposed and auto cleans up. Also avoid sharing servers for tests.

P.S. I get a **big** performance boost locally, the `request-listener.spec` ran for ~1min and now completes in ~4secs.
