### PR TITLE
Even more type improvements

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -59,7 +59,6 @@ export interface ServerAdapterObject<TServerContext> extends EventListenerObject
 }
 
 export type ServerAdapter<TServerContext> = ServerAdapterObject<TServerContext>['handle'] &
-  ServerAdapterObject<TServerContext>['requestListener'] &
   ServerAdapterObject<TServerContext>;
 
 async function handleWaitUntils(waitUntilPromises: Promise<unknown>[]) {


### PR DESCRIPTION
- Remove extraneous generics, they can confuse TS and mess with inference
- `ServerAdapter` implements `requestListener` too
- `NodeServerAdapterContext` (previously `DefaultServerAdapterContext`) is **not** the default context - it is the context only when using Node request handler. Shouldn't be used as default for context generic.