### PR TITLE
Node ponyfill requests must have an abort signal

### DIFF
--- a/.changeset/unlucky-lobsters-try.md
+++ b/.changeset/unlucky-lobsters-try.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/fetch': patch
+---
+
+Node ponyfill requests must have an abort signal

--- a/packages/fetch/dist/create-node-ponyfill.js
+++ b/packages/fetch/dist/create-node-ponyfill.js
@@ -255,6 +255,13 @@ module.exports = function createNodePonyfill(opts = {}) {
             super(requestOrUrl);
           }
           this.formData = getFormDataMethod(formDataModule.File, opts.formDataLimits);
+          this.requestSignal = this.signal;
+          this.optionsSignal = options?.signal || (new ponyfills.AbortController()).signal;
+        }
+        get signal() {
+          // node-fetch does not have a Request.signal
+          // https://github.com/node-fetch/node-fetch/issues/1439
+          return this.requestSignal || this.optionsSignal
         }
       }
       ponyfills.Request = Request;

--- a/packages/server/test/request-listener.spec.ts
+++ b/packages/server/test/request-listener.spec.ts
@@ -214,7 +214,7 @@ describe('Request Listener', () => {
       });
     });
 
-    it.only('should have the abort signal on the request', async () => {
+    it('should have the abort signal on the request', async () => {
       const handler = jest.fn((_request: Request) => new fetchAPI.Response());
       const adapter = createServerAdapter(handler, fetchAPI.Request);
 

--- a/packages/server/test/request-listener.spec.ts
+++ b/packages/server/test/request-listener.spec.ts
@@ -213,5 +213,14 @@ describe('Request Listener', () => {
         });
       });
     });
+
+    it.only('should have the abort signal on the request', async () => {
+      const handler = jest.fn((_request: Request) => new fetchAPI.Response());
+      const adapter = createServerAdapter(handler, fetchAPI.Request);
+
+      await adapter.fetch('http://localhost');
+
+      expect(handler.mock.lastCall?.[0].signal).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/dotansimha/graphql-yoga/issues/2304

node-fetch ponyfilled requests dont have an abort signal associated. See related issue: https://github.com/node-fetch/node-fetch/issues/1439.