### PR TITLE
Copy non-enumerable properties to server context

### DIFF
--- a/.changeset/wicked-experts-attend.md
+++ b/.changeset/wicked-experts-attend.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/server': patch
+---
+
+Copy non-enumerable properties to server context e.g. CF Workers' env and context


### PR DESCRIPTION
## Description

As discussed in https://github.com/dotansimha/graphql-yoga/pull/2324, this PR fixes copying non-enumerable properties to the server context.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

A test has been added that checks:
- if non-enumerable properties are copied
- if their non-enumerability is kept

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

