### PR TITLE
fix(events,fetch): avoid polluting global types

### DIFF
--- a/.changeset/soft-vans-invent.md
+++ b/.changeset/soft-vans-invent.md
@@ -1,0 +1,6 @@
+---
+'@whatwg-node/events': patch
+'@whatwg-node/fetch': patch
+---
+
+Restructure type declarations to avoid polluting global namespace.

--- a/packages/events/dist/index.d.ts
+++ b/packages/events/dist/index.d.ts
@@ -1,11 +1,7 @@
 /// <reference lib="dom" />
 
-declare const _Event: typeof Event;
-declare const _EventTarget: typeof EventTarget;
-declare const _CustomEvent: typeof CustomEvent;
-
 declare module "@whatwg-node/events" {
-    export const Event: typeof _Event;
-    export const EventTarget: typeof _EventTarget;
-    export const CustomEvent: typeof _CustomEvent;
+    export const Event: typeof globalThis.Event;
+    export const EventTarget: typeof globalThis.EventTarget;
+    export const CustomEvent: typeof globalThis.CustomEvent;
 }

--- a/packages/fetch/dist/index.d.ts
+++ b/packages/fetch/dist/index.d.ts
@@ -1,50 +1,28 @@
 /// <reference lib="dom" />
 /// <reference types="urlpattern-polyfill" />
 
-type ResponseCtorWithJson = typeof Response & {
-  json(data: any, init?: ResponseInit): Response;
-}
-
-declare const _fetch: typeof fetch;
-declare const _Request: typeof Request;
-declare const _Response: ResponseCtorWithJson;
-declare const _Headers: typeof Headers;
-declare const _FormData: typeof FormData;
-declare const _AbortSignal: typeof AbortSignal;
-declare const _AbortController: typeof AbortController;
-declare const _ReadableStream: typeof ReadableStream;
-declare const _WritableStream: typeof WritableStream;
-declare const _TransformStream: typeof TransformStream;
-declare const _Blob: typeof Blob;
-declare const _File: typeof File;
-declare const _crypto: typeof crypto;
-declare const _btoa: typeof btoa;
-declare const _TextEncoder: typeof TextEncoder;
-declare const _TextDecoder: typeof TextDecoder;
-declare const _URLPattern: typeof URLPattern;
-declare const _URL: typeof URL;
-declare const _URLSearchParams: typeof URLSearchParams;
-
-declare module "@whatwg-node/fetch" {
-  export const fetch: typeof _fetch;
-  export const Request: typeof _Request;
-  export const Response: typeof _Response;
-  export const Headers: typeof _Headers;
-  export const FormData: typeof _FormData;
-  export const AbortSignal: typeof _AbortSignal;
-  export const AbortController: typeof _AbortController;
-  export const ReadableStream: typeof _ReadableStream;
-  export const WritableStream: typeof _WritableStream;
-  export const TransformStream: typeof _TransformStream;
-  export const Blob: typeof _Blob;
-  export const File: typeof _File;
-  export const crypto: typeof _crypto;
-  export const btoa: typeof _btoa;
-  export const TextDecoder: typeof _TextDecoder;
-  export const TextEncoder: typeof _TextEncoder;
-  export const URL: typeof _URL;
-  export const URLSearchParams: typeof _URLSearchParams;
-  export const URLPattern: typeof _URLPattern;
+declare module '@whatwg-node/fetch' {
+  export const fetch: typeof globalThis.fetch;
+  export const Request: typeof globalThis.Request;
+  export const Response: typeof globalThis.Response & {
+    json(data: any, init?: ResponseInit): globalThis.Response;
+  };
+  export const Headers: typeof globalThis.Headers;
+  export const FormData: typeof globalThis.FormData;
+  export const AbortSignal: typeof globalThis.AbortSignal;
+  export const AbortController: typeof globalThis.AbortController;
+  export const ReadableStream: typeof globalThis.ReadableStream;
+  export const WritableStream: typeof globalThis.WritableStream;
+  export const TransformStream: typeof globalThis.TransformStream;
+  export const Blob: typeof globalThis.Blob;
+  export const File: typeof globalThis.File;
+  export const crypto: typeof globalThis.crypto;
+  export const btoa: typeof globalThis.btoa;
+  export const TextDecoder: typeof globalThis.TextDecoder;
+  export const TextEncoder: typeof globalThis.TextEncoder;
+  export const URL: typeof globalThis.URL;
+  export const URLSearchParams: typeof globalThis.URLSearchParams;
+  export const URLPattern: globalThis.URLPattern;
   export interface FormDataLimits {
     /* Max field name size (in bytes). Default: 100. */
     fieldNameSize?: number;
@@ -61,26 +39,28 @@ declare module "@whatwg-node/fetch" {
     /* For multipart forms, the max number of header key-value pairs to parse. Default: 2000. */
     headerSize?: number;
   }
-  export const createFetch: (opts?: { useNodeFetch?: boolean; formDataLimits?: FormDataLimits }) => ({
-    fetch: typeof _fetch,
-    Request: typeof _Request,
-    Response: typeof _Response,
-    Headers: typeof _Headers,
-    FormData: typeof _FormData,
-    AbortSignal: typeof _AbortSignal,
-    AbortController: typeof _AbortController,
-    ReadableStream: typeof _ReadableStream,
-    WritableStream: typeof _WritableStream,
-    TransformStream: typeof _TransformStream,
-    Blob: typeof _Blob,
-    File: typeof _File,
-    crypto: typeof _crypto,
-    btoa: typeof _btoa,
-    TextEncoder: typeof _TextEncoder,
-    TextDecoder: typeof _TextDecoder,
-    URLPattern: typeof _URLPattern,
-    URL: typeof _URL,
-    URLSearchParams: typeof _URLSearchParams,
-  });
+  export const createFetch: (opts?: {
+    useNodeFetch?: boolean;
+    formDataLimits?: FormDataLimits;
+  }) => {
+    fetch: typeof globalThis.fetch;
+    Request: typeof globalThis.Request;
+    Response: typeof globalThis.Response;
+    Headers: typeof globalThis.Headers;
+    FormData: typeof globalThis.FormData;
+    AbortSignal: typeof globalThis.AbortSignal;
+    AbortController: typeof globalThis.AbortController;
+    ReadableStream: typeof globalThis.ReadableStream;
+    WritableStream: typeof globalThis.WritableStream;
+    TransformStream: typeof globalThis.TransformStream;
+    Blob: typeof globalThis.Blob;
+    File: typeof globalThis.File;
+    crypto: typeof globalThis.crypto;
+    btoa: typeof globalThis.btoa;
+    TextEncoder: typeof globalThis.TextEncoder;
+    TextDecoder: typeof globalThis.TextDecoder;
+    URLPattern: globalThis.URLPattern;
+    URL: typeof globalThis.URL;
+    URLSearchParams: typeof globalThis.URLSearchParams;
+  };
 }
-


### PR DESCRIPTION
## Description

Sorry for going straight for a PR, I figured this fix was best described with code.

We're seeing issues with trying to use libraries that both declare global symbols such as `_fetch`, in this case this library along with `cross-fetch`. Due to these libraries both declaring this same global type, TypeScript will treat this as an error simply if both dependencies are installed in the same project. Using `--skipLibCheck` is not an option as this is an important check that we want to keep.

There are other solutions to this issue, but I figured the one I propose is the cleanest. `globalThis` has been available in TypeScript [since 3.4](https://devblogs.microsoft.com/typescript/announcing-typescript-3-4/#type-checking-for-globalthis), released 4 years ago.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] `yarn run ts:check`
- [x] The following manual procedure:
  - Install both `@whatwg-node/fetch` and `cross-fetch` in the same project
  - Run `tsc`, with `--skipLibCheck=false`. Multiple type errors are produced, for example:

    ```
    node_modules/@whatwg-node/fetch/dist/index.d.ts:8:15 - error TS2451: Cannot redeclare block-scoped variable '_fetch'.

    8 declare const _fetch: typeof fetch;
                    ~~~~~~

      node_modules/cross-fetch/index.d.ts:3:15
        3 declare const _fetch: typeof fetch;
                        ~~~~~~
        '_fetch' was also declared here.
    ```
  - Replace the contents of `node_modules/@whatwg-node/fetch/dist/index.d.ts` in the project with the contents from this PR.
  - Run `tsc` again, the errors are now gone and no new errors appear.
 
I applied the same fix to `events` to keep things consistent, but have not tested it in the same way.

**Test Environment**:

- OS: MacOS 13.2.1
- `typescript`: 4.7.4
- NodeJS: v16.14.2

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

