### PR TITLE
(feat:cookie-store) add httpOnly

### DIFF
--- a/.changeset/calm-cars-accept.md
+++ b/.changeset/calm-cars-accept.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/cookie-store': minor
+---
+
+add HttpOnly attribute

--- a/packages/cookie-store/src/CookieStore.ts
+++ b/packages/cookie-store/src/CookieStore.ts
@@ -41,6 +41,7 @@ export class CookieStore extends EventTarget {
       sameSite: 'strict',
       expires: null,
       domain: null,
+      httpOnly: false,
     };
     if (typeof init === 'string') {
       item.name = init as string;
@@ -118,6 +119,7 @@ export class CookieStore extends EventTarget {
       sameSite: 'strict',
       expires: null,
       domain: null,
+      httpOnly: false,
     };
     if (typeof init === 'string') {
       item.name = init as string;

--- a/packages/cookie-store/src/getCookieString.ts
+++ b/packages/cookie-store/src/getCookieString.ts
@@ -35,5 +35,9 @@ export function getCookieString(item: CookieListItem | Cookie) {
       break;
   }
 
+  if (item.httpOnly) {
+    cookieString += '; HttpOnly';
+  }
+
   return cookieString;
 }

--- a/packages/cookie-store/src/types.ts
+++ b/packages/cookie-store/src/types.ts
@@ -6,6 +6,7 @@ export interface Cookie {
   secure?: boolean;
   sameSite?: CookieSameSite;
   value: string;
+  httpOnly?: boolean;
 }
 
 export interface CookieStoreDeleteOptions {
@@ -29,6 +30,7 @@ export interface CookieListItem {
   expires: Date | number | null;
   secure?: boolean;
   sameSite?: CookieSameSite;
+  httpOnly?: boolean;
 }
 
 export type CookieList = CookieListItem[];

--- a/packages/cookie-store/test/getCookieString.spec.ts
+++ b/packages/cookie-store/test/getCookieString.spec.ts
@@ -55,4 +55,13 @@ describe('getCookieString helper', () => {
       }),
     ).toBe(`foo=bar; Secure; SameSite=Lax`);
   });
+
+  it('should work with HttpOnly', () => {
+    expect(
+      getCookieString({
+        ...baseOptions,
+        httpOnly: true,
+      }),
+    ).toBe(`foo=bar; HttpOnly`);
+  });
 });


### PR DESCRIPTION

## Description

Add the possibility to create HttpOnly cookies

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
