### PR TITLE
fix(node-fetch): resolve immediately if the body is empty

### DIFF
--- a/.changeset/clean-schools-behave.md
+++ b/.changeset/clean-schools-behave.md
@@ -2,4 +2,5 @@
 '@whatwg-node/node-fetch': patch
 ---
 
-Respect empty responses and do not hang
+Fix the bug causing the stream hang when the response body is empty.
+Related https://github.com/ardatan/whatwg-node/issues/703

--- a/.changeset/clean-schools-behave.md
+++ b/.changeset/clean-schools-behave.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/node-fetch': patch
+---
+
+Respect empty responses and do not hang

--- a/packages/node-fetch/src/Body.ts
+++ b/packages/node-fetch/src/Body.ts
@@ -136,8 +136,9 @@ export class PonyfillBody<TJSON = any> implements Body {
         _body.readable.on('error', e => {
           reject(e);
         });
+      } else {
+        resolve(chunks);
       }
-      return chunks;
     });
   }
 

--- a/packages/node-fetch/tests/Body.spec.ts
+++ b/packages/node-fetch/tests/Body.spec.ts
@@ -50,4 +50,9 @@ describe('Body', () => {
       expect(body.blob).not.toHaveBeenCalled();
     });
   });
+  it('works with empty responses', async () => {
+    const body = new PonyfillBody(null);
+    const result = await body.text();
+    expect(result).toBe('');
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/ardatan/whatwg-node/issues/703