### PR TITLE
added a passing test + failure example

### DIFF
--- a/packages/server/test/fastify-failure-example.js
+++ b/packages/server/test/fastify-failure-example.js
@@ -1,0 +1,48 @@
+import fastify from 'fastify';
+import { createServerAdapter } from '@whatwg-node/server';
+
+const run = async () => {
+  const myServerAdapter = createServerAdapter(() => {
+    return new Response('Hello World');
+  });
+
+  const app = fastify({
+    logger: true,
+  });
+
+  app.route({
+    url: '/mypath',
+    method: ['GET', 'POST', 'OPTIONS'],
+    handler: async (req, reply) => {
+      const response = await myServerAdapter.handleNodeRequest(req, {
+        req,
+        reply,
+      });
+      response.headers.forEach((value, key) => {
+        reply.header(key, value);
+      });
+
+      reply.status(response.status);
+
+      reply.send(response.body);
+
+      return reply;
+    },
+  });
+
+  console.log('Starting server...');
+  await app.listen({
+    port: 3000,
+  });
+  console.log('Server started.');
+
+  console.log('Sending request...');
+  const response = await fetch('http://localhost:3000/mypath');
+  console.log('Request sent.');
+
+  console.log('Response status:', response.status);
+
+  await app.close();
+};
+
+run();

--- a/packages/server/test/fastify.spec.ts
+++ b/packages/server/test/fastify.spec.ts
@@ -146,3 +146,42 @@ describe('Fastify', () => {
     expect(res.statusCode).toBe(status);
   });
 });
+
+describe('fastify + simple get', () => {
+  it('should return get response via reply.send(response.body)', async () => {
+    const myServerAdapter = createServerAdapter(() => {
+      return new Response('Hello World');
+    });
+
+    const app = fastify({
+      logger: true,
+    });
+
+    app.route({
+      url: '/mypath',
+      method: ['GET', 'POST', 'OPTIONS'],
+      handler: async (req, reply) => {
+        const response = await myServerAdapter.handleNodeRequest(req, {
+          req,
+          reply,
+        });
+        response.headers.forEach((value, key) => {
+          reply.header(key, value);
+        });
+
+        reply.status(response.status);
+
+        reply.send(response.body);
+
+        return reply;
+      },
+    });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/mypath',
+    });
+
+    expect(response.body).toBe('Hello World');
+  });
+});


### PR DESCRIPTION
@ardatan here's your requested test for fastify. the test is actually passing, but it still fails when i run it outside of jest. 

`yarn test` will pass, which is confusing but i guess it has something to do with the differences between `fastify.inject` and actual runtime behavior. could you try running `node ./packages/server/test/fastify-failure-example.js`? when i run this example script, i get the error printout below:

Addendum:
It works if you use `@whatwg-node/fetch` instead of the regular fetch api. So I think this isn't really a bug, as much as a documentation issue

```
Starting server...
{"level":30,"time":1703177441925,"pid":9056,"hostname":"Kerems-MacBook-Pro.local","msg":"Server listening at http://[::1]:3000"}
{"level":30,"time":1703177441926,"pid":9056,"hostname":"Kerems-MacBook-Pro.local","msg":"Server listening at http://127.0.0.1:3000"}
Server started.
Sending request...
{"level":30,"time":1703177441941,"pid":9056,"hostname":"Kerems-MacBook-Pro.local","reqId":"req-1","req":{"method":"GET","url":"/mypath","hostname":"localhost:3000","remoteAddress":"::1","remotePort":50572},"msg":"incoming request"}
{"level":50,"time":1703177441943,"pid":9056,"hostname":"Kerems-MacBook-Pro.local","reqId":"req-1","req":{"method":"GET","url":"/mypath","hostname":"localhost:3000","remoteAddress":"::1","remotePort":50572},"res":{"statusCode":500},"err":{"type":"FastifyError","message":"Attempted to send payload of invalid type 'object'. Expected a string or Buffer.","stack":"FastifyError: Attempted to send payload of invalid type 'object'. Expected a string or Buffer.\n    at onSendEnd (/Users/keremkazan/Documents/projects/whatwg-node/node_modules/fastify/lib/reply.js:617:11)\n    at onSendHook (/Users/keremkazan/Documents/projects/whatwg-node/node_modules/fastify/lib/reply.js:541:5)\n    at Reply.send (/Users/keremkazan/Documents/projects/whatwg-node/node_modules/fastify/lib/reply.js:209:3)\n    at Object.handler (file:///Users/keremkazan/Documents/projects/whatwg-node/packages/server/test/fastify-failure-example.js:27:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)","code":"FST_ERR_REP_INVALID_PAYLOAD_TYPE","name":"FastifyError","statusCode":500},"msg":"Attempted to send payload of invalid type 'object'. Expected a string or Buffer."}
{"level":30,"time":1703177441945,"pid":9056,"hostname":"Kerems-MacBook-Pro.local","reqId":"req-1","res":{"statusCode":500},"responseTime":4.206459000008181,"msg":"request completed"}
Request sent.
Response status: 500
```