### PR TITLE
Adds test against fetch calls where an AbortSignal hits a streaming response

### DIFF
--- a/.changeset/fresh-cameras-search.md
+++ b/.changeset/fresh-cameras-search.md
@@ -1,0 +1,5 @@
+---
+"@whatwg-node/node-fetch": patch
+---
+
+Fix abort logic for node-libcurl

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,14 +11,17 @@ let globals = {};
 
 try {
   global.uwsUtils = require('./uwsUtils');
-} catch (e) {
-  console.warn(`Failed to load uWebSockets.js. Skipping tests that require it.`);
+} catch (err) {
+  console.warn(`Failed to load uWebSockets.js. Skipping tests that require it.`, err);
 }
 
 try {
   globals.libcurl = require('node-libcurl');
 } catch (err) {
-  console.log('Failed to load node-libcurl. Skipping tests that require it.');
+  if (process.env.CI) {
+    throw new Error('Failed to load node-libcurl.');
+  }
+  console.warn('Failed to load node-libcurl. Skipping tests that require it.', err);
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "test:leaks": "LEAK_TEST=1 jest --runInBand --detectOpenHandles --detectLeaks --logHeapUsage --forceExit",
     "ts:check": "tsc --noEmit"
   },
-  "optionalDependencies": {
-    "node-libcurl": "3.0.1-0"
-  },
   "devDependencies": {
     "@babel/core": "7.23.7",
     "@babel/plugin-proposal-class-properties": "7.18.6",
@@ -53,6 +50,7 @@
     "husky": "8.0.3",
     "jest": "29.7.0",
     "lint-staged": "15.2.0",
+    "node-libcurl": "3.0.1-0",
     "patch-package": "8.0.0",
     "prettier": "3.1.1",
     "rimraf": "5.0.5",

--- a/packages/node-fetch/src/declarations.d.ts
+++ b/packages/node-fetch/src/declarations.d.ts
@@ -32,4 +32,4 @@ declare module '@kamilkisiela/fast-url-parser' {
 }
 
 // TODO
-declare var libcurl: typeof import('node-libcurl');
+declare var libcurl: any;

--- a/packages/node-fetch/src/declarations.d.ts
+++ b/packages/node-fetch/src/declarations.d.ts
@@ -32,4 +32,4 @@ declare module '@kamilkisiela/fast-url-parser' {
 }
 
 // TODO
-declare var libcurl: any;
+declare var libcurl: typeof import('node-libcurl');

--- a/packages/node-fetch/src/fetchCurl.ts
+++ b/packages/node-fetch/src/fetchCurl.ts
@@ -1,5 +1,4 @@
 import { Readable } from 'node:stream';
-import { PonyfillAbortError } from './AbortError.js';
 import { PonyfillRequest } from './Request.js';
 import { PonyfillResponse } from './Response.js';
 import { defaultHeadersSerializer, isNodeReadable } from './utils.js';

--- a/packages/node-fetch/src/fetchCurl.ts
+++ b/packages/node-fetch/src/fetchCurl.ts
@@ -7,7 +7,7 @@ import { defaultHeadersSerializer, isNodeReadable } from './utils.js';
 export function fetchCurl<TResponseJSON = any, TRequestJSON = any>(
   fetchRequest: PonyfillRequest<TRequestJSON>,
 ): Promise<PonyfillResponse<TResponseJSON>> {
-  const { Curl, CurlCode, CurlFeature, CurlPause, CurlProgressFunc } = globalThis['libcurl'];
+  const { Curl, CurlFeature, CurlPause, CurlProgressFunc } = globalThis['libcurl'];
 
   const curlHandle = new Curl();
 
@@ -75,13 +75,8 @@ export function fetchCurl<TResponseJSON = any, TRequestJSON = any>(
     let streamResolved: Readable | undefined;
     if (fetchRequest['_signal']) {
       fetchRequest['_signal'].onabort = () => {
-        if (streamResolved) {
-          if (curlHandle.isOpen) {
-            curlHandle.pause(CurlPause.Recv);
-          }
-        } else {
-          reject(new PonyfillAbortError());
-          curlHandle.close();
+        if (curlHandle.isOpen) {
+          curlHandle.pause(CurlPause.Recv);
         }
       };
     }
@@ -108,6 +103,7 @@ export function fetchCurl<TResponseJSON = any, TRequestJSON = any>(
                 fetchRequest.redirect === 'error' &&
                 (headerFilter.includes('location') || headerFilter.includes('Location'))
               ) {
+                stream.destroy();
                 reject(new Error('redirect is not allowed'));
               }
               return true;

--- a/packages/node-fetch/src/fetchCurl.ts
+++ b/packages/node-fetch/src/fetchCurl.ts
@@ -76,9 +76,12 @@ export function fetchCurl<TResponseJSON = any, TRequestJSON = any>(
     if (fetchRequest['_signal']) {
       fetchRequest['_signal'].onabort = () => {
         if (streamResolved) {
+          // TODO: Remove this console.log before merging. Helpful to make sure code path is being hit by test.
+          console.log('ℹ️ Hit streamed response abort handler');
           if (curlHandle.isOpen) {
             curlHandle.pause(CurlPause.Recv);
           }
+          // QUESTION: Should we be rejecting with abort here? And should the curlHandle be closed?
         } else {
           reject(new PonyfillAbortError());
           curlHandle.close();

--- a/packages/node-fetch/tests/fetch.spec.ts
+++ b/packages/node-fetch/tests/fetch.spec.ts
@@ -7,8 +7,7 @@ import { PonyfillReadableStream } from '../src/ReadableStream.js';
 
 describe('Node Fetch Ponyfill', () => {
   runTestsForEachFetchImpl(implementationName => {
-    // const baseUrl = process.env.CI ? 'http://localhost:8888' : 'https://httpbin.org';
-    const baseUrl = 'https://httpbin.org';
+    const baseUrl = process.env.CI ? 'http://localhost:8888' : 'https://httpbin.org';
     it('should fetch', async () => {
       const response = await fetchPonyfill(baseUrl + '/get');
       expect(response.status).toBe(200);

--- a/packages/node-fetch/tests/fetch.spec.ts
+++ b/packages/node-fetch/tests/fetch.spec.ts
@@ -6,7 +6,7 @@ import { PonyfillFormData } from '../src/FormData.js';
 import { PonyfillReadableStream } from '../src/ReadableStream.js';
 
 describe('Node Fetch Ponyfill', () => {
-  runTestsForEachFetchImpl(implementationName => {
+  runTestsForEachFetchImpl(() => {
     const baseUrl = process.env.CI ? 'http://localhost:8888' : 'https://httpbin.org';
     it('should fetch', async () => {
       const response = await fetchPonyfill(baseUrl + '/get');
@@ -120,36 +120,28 @@ describe('Node Fetch Ponyfill', () => {
         }),
       ).rejects.toThrow('aborted');
     });
-    // TODO: Remove .only on test before merging.
-    // TODO: Remove console.logs before merging.
-    it.only('should respect AbortSignal on a streamed response', async () => {
-      console.log(`should respect AbortSignal on a streamed response (${implementationName})`);
+    it('should respect AbortSignal on a streamed response', async () => {
       expect.assertions(1);
       const controller = new AbortController();
       const fetchPromise = fetchPonyfill(baseUrl + `/stream-bytes/${10 * 1024 * 1024 * 1024}`, {
         signal: controller.signal,
       });
-      // NOTE: We have tried to reduce the time below 2 seconds, but when doing so it doesn't
-      // appear that we always hit the streamed response abort code path.
-      setTimeout(() => {
-        console.log('Aborting');
-        controller.abort();
-      }, 2000);
       try {
         const response = await fetchPromise;
         if (!response || !response.body) {
           throw new Error('Response or response body is null');
         }
-        for await (const chunk of response.body) {
+        let cnt = 0;
+        for await (const _ of response.body) {
           if (controller.signal.aborted) {
-            console.log("Controller's signal is aborted");
-            break;
+            throw new Error('aborted but stream leaks');
           }
-          console.log('Received chunk of size', chunk.length);
+          cnt++;
+          if (cnt === 4) {
+            controller.abort();
+          }
         }
-        console.log('Done');
       } catch (err: any) {
-        console.log(err);
         expect(err.message).toMatch(/aborted/);
       }
     });

--- a/packages/server/test/test-fetch.ts
+++ b/packages/server/test/test-fetch.ts
@@ -3,7 +3,7 @@ import { globalAgent as httpsGlobalAgent } from 'node:https';
 
 const libcurl = globalThis.libcurl;
 export function runTestsForEachFetchImpl(callback: () => void) {
-  if (!libcurl) {
+  if (libcurl) {
     describe('libcurl', () => {
       callback();
     });

--- a/packages/server/test/test-fetch.ts
+++ b/packages/server/test/test-fetch.ts
@@ -2,10 +2,11 @@ import { globalAgent as httpGlobalAgent } from 'node:http';
 import { globalAgent as httpsGlobalAgent } from 'node:https';
 
 const libcurl = globalThis.libcurl;
-export function runTestsForEachFetchImpl(callback: () => void) {
+export function runTestsForEachFetchImpl(callback: (implementationName: string) => void) {
   if (libcurl) {
     describe('libcurl', () => {
-      callback();
+      // eslint-disable-next-line n/no-callback-literal
+      callback('libcurl');
     });
   }
   describe('node-http', () => {
@@ -17,6 +18,7 @@ export function runTestsForEachFetchImpl(callback: () => void) {
       httpGlobalAgent.destroy();
       httpsGlobalAgent.destroy();
     });
-    callback();
+    // eslint-disable-next-line n/no-callback-literal
+    callback('libcurl');
   });
 }

--- a/packages/server/test/test-fetch.ts
+++ b/packages/server/test/test-fetch.ts
@@ -1,3 +1,4 @@
+/* eslint-disable n/no-callback-literal */
 import { globalAgent as httpGlobalAgent } from 'node:http';
 import { globalAgent as httpsGlobalAgent } from 'node:https';
 
@@ -5,7 +6,6 @@ const libcurl = globalThis.libcurl;
 export function runTestsForEachFetchImpl(callback: (implementationName: string) => void) {
   if (libcurl) {
     describe('libcurl', () => {
-      // eslint-disable-next-line n/no-callback-literal
       callback('libcurl');
     });
   }
@@ -18,7 +18,6 @@ export function runTestsForEachFetchImpl(callback: (implementationName: string) 
       httpGlobalAgent.destroy();
       httpsGlobalAgent.destroy();
     });
-    // eslint-disable-next-line n/no-callback-literal
-    callback('libcurl');
+    callback('node-http');
   });
 }


### PR DESCRIPTION
This PR is to help identify/address an issue we reported with the Guild team via Slack communications.

## Description

We are experiencing issues with aborts against `libcurl` powered requests where the responses are being streamed.

![image](https://github.com/ardatan/whatwg-node/assets/12164768/7eb2da69-cf49-4e81-98eb-3d7d8069a0a8)

The above code, when hit, produces the following error:

```s
A libcurl function was given a bad argument
  at Curl.pause (node_modules/node-libcurl/lib/Curl.ts:780:13)
  at EventTarget.fetchRequest._signal.onabort (node_modules/@whatwg-node/node-fetch/cjs/fetchCurl.js:61:36)
```

I have tried to reproduce this via a test, but in doing this I think I have uncovered other potential issues with the tests configuration and the implementation of the `libcurl` wrapper.

The test runs successfully for the `node-fetch` implementation run, but fails for the `libcurl` implementation run.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

