### PR TITLE
Support native `ReadableStream` as `BodyInit` & tests for React streaming response w/ Fastify

### DIFF
--- a/.changeset/long-suits-train.md
+++ b/.changeset/long-suits-train.md
@@ -2,4 +2,4 @@
 "@whatwg-node/node-fetch": patch
 ---
 
-Support native ReadableStream in PonyfillResponse
+Support native `ReadableStream` as `BodyInit`

--- a/.changeset/long-suits-train.md
+++ b/.changeset/long-suits-train.md
@@ -1,0 +1,5 @@
+---
+"@whatwg-node/node-fetch": patch
+---
+
+Support native ReadableStream in PonyfillResponse

--- a/packages/node-fetch/src/Body.ts
+++ b/packages/node-fetch/src/Body.ts
@@ -299,7 +299,7 @@ function processBodyInit(bodyInit: BodyPonyfillInit | null): {
       },
     };
   }
-  if (bodyInit instanceof PonyfillReadableStream) {
+  if (bodyInit instanceof PonyfillReadableStream && bodyInit.readable != null) {
     return {
       bodyType: BodyInitType.ReadableStream,
       bodyFactory: () => bodyInit,

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -61,7 +61,7 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
       | ReadableStream<T>
       | PonyfillReadableStream<T>,
   ) {
-    if (underlyingSource instanceof PonyfillReadableStream) {
+    if (underlyingSource instanceof PonyfillReadableStream && underlyingSource.readable != null) {
       this.readable = underlyingSource.readable;
     } else if (isNodeReadable(underlyingSource)) {
       this.readable = underlyingSource as Readable;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -42,6 +42,8 @@
     "@types/node": "20.11.6",
     "express": "4.18.2",
     "fastify": "4.25.2",
+    "react": "0.0.0-experimental-e5205658f-20230913",
+    "react-dom": "0.0.0-experimental-e5205658f-20230913",
     "uWebSockets.js": "uNetworking/uWebSockets.js#v20.34.0"
   },
   "publishConfig": {
@@ -56,3 +58,4 @@
     "definition": "dist/typings/index.d.ts"
   }
 }
+

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -58,4 +58,3 @@
     "definition": "dist/typings/index.d.ts"
   }
 }
-

--- a/packages/server/test/fastify.spec.ts
+++ b/packages/server/test/fastify.spec.ts
@@ -158,7 +158,7 @@ describe('Fastify', () => {
 
       const stream = await renderToReadableStream(React.createElement(MyComponent));
 
-      return stream;
+      return new Response(stream);
     });
 
     const fastifyServer = fastify();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7735,6 +7735,14 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-dom@0.0.0-experimental-e5205658f-20230913:
+  version "0.0.0-experimental-e5205658f-20230913"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-experimental-e5205658f-20230913.tgz#5eb3f8f6e660f3498fcf81fdefd15f3f1d7130dc"
+  integrity sha512-Lnv7ObEPUBh/G2NoF2/1nmueYY5vmKsfgEBlG5gjMXeDgbKAf7yYI+wK49URKP9RyJRMjTOUcBghtM+nUwPWdg==
+  dependencies:
+    loose-envify "^1.1.0"
+    scheduler "0.0.0-experimental-e5205658f-20230913"
+
 react-dom@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -7752,6 +7760,13 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react@0.0.0-experimental-e5205658f-20230913:
+  version "0.0.0-experimental-e5205658f-20230913"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-experimental-e5205658f-20230913.tgz#b14fd35fea76cb1e86c84982c304a4ddea752455"
+  integrity sha512-Vbc4OkA2YHmlUUr4bvzkaxnpTpJO/N7AMIRrlUFzU6rhbaQWp0+GisxQrsEJd1oLd8kpnXbf6LUiBRfhT/JZ3g==
+  dependencies:
+    loose-envify "^1.1.0"
 
 react@18.2.0:
   version "18.2.0"
@@ -8139,6 +8154,13 @@ sax@1.2.1, sax@>=0.6.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
   integrity sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==
+
+scheduler@0.0.0-experimental-e5205658f-20230913:
+  version "0.0.0-experimental-e5205658f-20230913"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-experimental-e5205658f-20230913.tgz#ac5599f9923a751365cbf834cdf333542dd3f6fb"
+  integrity sha512-EGj1PauhuhJnJz0vr341m1MAUeX+hrsLVWwl0Uh/TKOVXWNSRn8BngAivX81HwgUTab9RETU81o1L2jmIo1CeA==
+  dependencies:
+    loose-envify "^1.1.0"
 
 scheduler@^0.23.0:
   version "0.23.0"


### PR DESCRIPTION
No issue yet!

## Description
When using `createServerAdapter` in fastify to render React to readable streams, the adapter errors out with the following message:

```
Cannot create proxy with a non-object as target or handler
```

Related # (issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

**Test Environment**:

- OS: MacOS
- `server`: main
- NodeJS: v20.10.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
This is an initial test to kick off discussion, I'm not sure whether you will want react as a devDependency in your repo. If you're okay with this I will add the same tests to express.spec and node.spec (which will probably pass)
