### PR TITLE
docs(server): update deno section

### DIFF
--- a/e2e/deno/e2e.ts
+++ b/e2e/deno/e2e.ts
@@ -1,10 +1,10 @@
-import { serve } from 'https://deno.land/std@0.157.0/http/server.ts';
 import { assertDeployedEndpoint } from '@e2e/shared-scripts';
 import { createTestServerAdapter } from '@e2e/shared-server';
 
 const abortCtrl = new AbortController();
 const url = await new Promise(resolve => {
-  serve(createTestServerAdapter(), {
+  Deno.serve({
+    handler: createTestServerAdapter(),
     onListen({ hostname, port }) {
       resolve(`http://${hostname}:${port}`);
     },

--- a/e2e/deno/tsconfig.json
+++ b/e2e/deno/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": false,
+    "inlineSourceMap": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "lib": ["deno.window"],
+    "module": "esnext",
+    "moduleDetection": "force",
+    "strict": true,
+    "target": "esnext",
+    "useDefineForClassFields": true
+  }
+}

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -114,8 +114,7 @@ self.addEventListener('fetch', myServerAdapter)
 ### Deno
 
 [Deno is a simple, modern and secure runtime for JavaScript and TypeScript that uses V8 and is built in Rust](https://deno.land/).
-Although an adapter is not needed when using [`Deno.serve`](https://deno.land/api?s=Deno.serve), one can be used as a
-Deno request handler as shown below:
+You can use our adapter as a Deno request handler like below;
 
 ```ts
 import myServerAdapter from './myServerAdapter.ts'

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -114,17 +114,13 @@ self.addEventListener('fetch', myServerAdapter)
 ### Deno
 
 [Deno is a simple, modern and secure runtime for JavaScript and TypeScript that uses V8 and is built in Rust](https://deno.land/).
-You can use our adapter as a Deno request handler like below;
+Although an adapter is not needed when using [`Deno.serve`](https://deno.land/api?s=Deno.serve), one can be used as a
+Deno request handler as shown below:
 
 ```ts
-import { serve } from 'https://deno.land/std@0.157.0/http/server.ts'
-import myServerAdapter from './myServerAdapter'
+import myServerAdapter from './myServerAdapter.ts'
 
-serve(myServerAdapter, {
-  onListen({ hostname, port }) {
-    console.log(`Listening on http://${hostname}:${port}/graphql`)
-  }
-})
+Deno.serve(myServerAdapter)
 ```
 
 ### Express


### PR DESCRIPTION
[`Deno.serve`](https://deno.land/api?s=Deno.serve) was stabilized in Deno [v1.35.0](https://github.com/denoland/deno/releases/tag/v1.35.0) back in 2023 July. This updates the documentation example to use the current API.

Ref: [stabilization announcement in the Deno blog](https://deno.com/blog/v1.35#denoserve-is-now-stable)