### PR TITLE
Better fastify support

### DIFF
--- a/.changeset/nine-dingos-appear.md
+++ b/.changeset/nine-dingos-appear.md
@@ -1,0 +1,30 @@
+---
+"@whatwg-node/node-fetch": patch
+"@whatwg-node/server": patch
+---
+
+Now the server adapter created with `@whatwg-node/server` can be used with Fastify easier;
+
+```ts
+import fastify from 'fastify'
+import myServerAdapter from './myServerAdapter'
+
+// This is the fastify instance you have created
+const app = fastify({ logger: true })
+
+/**
+ * We pass the incoming HTTP request to our adapter
+ * and handle the response using Fastify's `reply` API
+ * Learn more about `reply` https://www.fastify.io/docs/latest/Reply/
+ **/
+app.route({
+  url: '/mypath',
+  method: ['GET', 'POST', 'OPTIONS'],
+  handler: (req, reply) => myServerAdapter.handleNodeRequestAndResponse(req, reply, {
+      req,
+      reply
+    })
+})
+
+app.listen(4000)
+```

--- a/packages/fetch/dist/create-node-ponyfill.js
+++ b/packages/fetch/dist/create-node-ponyfill.js
@@ -43,6 +43,8 @@ module.exports = function createNodePonyfill(opts = {}) {
   ponyfills.Headers = newNodeFetch.Headers;
   ponyfills.FormData = newNodeFetch.FormData;
   ponyfills.ReadableStream = newNodeFetch.ReadableStream;
+  
+  newNodeFetch.patchReadableFromWeb();
 
   ponyfills.URL = newNodeFetch.URL;
   ponyfills.URLSearchParams = newNodeFetch.URLSearchParams;

--- a/packages/fetch/dist/node-ponyfill.js
+++ b/packages/fetch/dist/node-ponyfill.js
@@ -8,11 +8,6 @@ if (!shouldSkipPonyfill()) {
   if (!globalThis.libcurl) {
     try {
       globalThis.libcurl = require(nodelibcurlName);
-      if (typeof jest === 'object' && typeof afterEach === 'function') {
-        afterEach(() => {
-          delete globalThis.libcurl;
-        });
-      }
     } catch (e) { }
   }
 }

--- a/packages/fetch/dist/node-ponyfill.js
+++ b/packages/fetch/dist/node-ponyfill.js
@@ -4,10 +4,17 @@ const shouldSkipPonyfill = require('./shouldSkipPonyfill');
 const ponyfills = createNodePonyfill();
 
 if (!shouldSkipPonyfill()) {
-  try {
-    const nodelibcurlName = 'node-libcurl'
-    globalThis.libcurl = globalThis.libcurl || require(nodelibcurlName);
-  } catch (e) { }
+  const nodelibcurlName = 'node-libcurl'
+  if (!globalThis.libcurl) {
+    try {
+      globalThis.libcurl = require(nodelibcurlName);
+      if (typeof jest === 'object' && typeof afterEach === 'function') {
+        afterEach(() => {
+          delete globalThis.libcurl;
+        });
+      }
+    } catch (e) { }
+  }
 }
 
 module.exports.fetch = ponyfills.fetch;

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -202,6 +202,8 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
   static [Symbol.hasInstance](instance: unknown): instance is PonyfillReadableStream<unknown> {
     return isReadableStream(instance);
   }
+
+  [Symbol.toStringTag] = 'ReadableStream';
 }
 
 function isPonyfillWritableStream(obj: any): obj is PonyfillWritableStream {

--- a/packages/node-fetch/src/Response.ts
+++ b/packages/node-fetch/src/Response.ts
@@ -90,4 +90,6 @@ export class PonyfillResponse<TJSON = any> extends PonyfillBody<TJSON> implement
     }
     return new PonyfillResponse<T>(JSON.stringify(data), init);
   }
+
+  [Symbol.toStringTag] = 'Response';
 }

--- a/packages/node-fetch/src/index.ts
+++ b/packages/node-fetch/src/index.ts
@@ -1,3 +1,5 @@
+export { patchReadableFromWeb } from './utils.js';
+
 export { fetchPonyfill as fetch } from './fetch.js';
 export { PonyfillHeaders as Headers } from './Headers.js';
 export { PonyfillBody as Body } from './Body.js';

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -4,6 +4,26 @@ function isHeadersInstance(obj: any): obj is Headers {
   return obj?.forEach != null;
 }
 
+export function patchReadableFromWeb() {
+  try {
+    const originalReadableFromWeb = Readable.fromWeb;
+
+    if (originalReadableFromWeb.name !== 'ReadableFromWebPatchedByWhatWgNode') {
+      Readable.fromWeb = function ReadableFromWebPatchedByWhatWgNode(stream: any): Readable {
+        if (stream.readable != null) {
+          return stream.readable;
+        }
+        return originalReadableFromWeb(stream as any);
+      };
+    }
+  } catch (e) {
+    console.warn(
+      'Could not patch Readable.fromWeb, so this might break Readable.fromWeb usage with the whatwg-node and the integrations like Fastify',
+      e,
+    );
+  }
+}
+
 export function getHeadersObj(headers: Headers): Record<string, string> {
   if (headers == null || !isHeadersInstance(headers)) {
     return headers as any;

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -15,6 +15,12 @@ export function patchReadableFromWeb() {
         }
         return originalReadableFromWeb(stream as any);
       };
+      if (typeof jest === 'object' && typeof afterEach === 'function') {
+        // To relax jest, we should remove the patch after each test
+        afterEach(() => {
+          Readable.fromWeb = originalReadableFromWeb;
+        });
+      }
     }
   } catch (e) {
     console.warn(

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -14,25 +14,26 @@ export function patchReadableFromWeb() {
       }
       return originalReadableFromWeb(stream as any);
     }
-    if (
-      typeof jest === 'object' &&
-      typeof beforeEach === 'function' &&
-      typeof afterEach === 'function' &&
-      originalReadableFromWeb.name !== 'ReadableFromWebPatchedByWhatWgNode'
-    ) {
-      // To relax jest, we should remove the patch after each test
-      beforeEach(() => {
-        if (Readable.fromWeb.name !== 'ReadableFromWebPatchedByWhatWgNode') {
-          Readable.fromWeb = ReadableFromWebPatchedByWhatWgNode;
-        }
-      });
-      afterEach(() => {
-        if (Readable.fromWeb.name === 'ReadableFromWebPatchedByWhatWgNode') {
-          Readable.fromWeb = originalReadableFromWeb;
-        }
-      });
-    } else if (originalReadableFromWeb.name !== 'ReadableFromWebPatchedByWhatWgNode') {
-      Readable.fromWeb = ReadableFromWebPatchedByWhatWgNode;
+    if (originalReadableFromWeb.name !== 'ReadableFromWebPatchedByWhatWgNode') {
+      if (
+        typeof jest === 'object' &&
+        typeof beforeEach === 'function' &&
+        typeof afterEach === 'function'
+      ) {
+        // To relax jest, we should remove the patch after each test
+        beforeEach(() => {
+          if (Readable.fromWeb.name !== 'ReadableFromWebPatchedByWhatWgNode') {
+            Readable.fromWeb = ReadableFromWebPatchedByWhatWgNode;
+          }
+        });
+        afterEach(() => {
+          if (Readable.fromWeb.name === 'ReadableFromWebPatchedByWhatWgNode') {
+            Readable.fromWeb = originalReadableFromWeb;
+          }
+        });
+      } else {
+        Readable.fromWeb = ReadableFromWebPatchedByWhatWgNode;
+      }
     }
   } catch (e) {
     console.warn(

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -16,6 +16,7 @@ export function patchReadableFromWeb() {
     }
     if (
       typeof jest === 'object' &&
+      typeof beforeEach === 'function' &&
       typeof afterEach === 'function' &&
       originalReadableFromWeb.name !== 'ReadableFromWebPatchedByWhatWgNode'
     ) {

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -152,7 +152,7 @@ So you can benefit from the powerful plugins of Fastify ecosystem.
 [See the ecosystem](https://www.fastify.io/docs/latest/Guides/Ecosystem/)
 
 ```ts
-import fastify, { FastifyReply, FastifyRequest } from 'fastify'
+import fastify from 'fastify'
 import myServerAdapter from './myServerAdapter'
 
 // This is the fastify instance you have created
@@ -166,22 +166,11 @@ const app = fastify({ logger: true })
 app.route({
   url: '/mypath',
   method: ['GET', 'POST', 'OPTIONS'],
-  handler: async (req, reply) => {
-    const response = await myServerAdapter.handleNodeRequestAndResponse(req, reply, {
+  handler: (req, reply) =>
+    myServerAdapter.handleNodeRequestAndResponse(req, reply, {
       req,
       reply
     })
-    response.headers.forEach((value, key) => {
-      reply.header(key, value)
-    })
-
-    reply.status(response.status)
-
-    // Fastify doesn't accept `null` as a response body
-    reply.send(response.body || undefined)
-
-    return reply
-  }
 })
 
 app.listen(4000)

--- a/packages/server/test/fastify.spec.ts
+++ b/packages/server/test/fastify.spec.ts
@@ -15,27 +15,6 @@ interface FastifyServerContext {
 
 type FastifyServerAdapter = ServerAdapter<any, ServerAdapterBaseObject<any>>;
 
-async function handleFastify(
-  serverAdapter: FastifyServerAdapter,
-  req: FastifyRequest,
-  reply: FastifyReply,
-) {
-  const response = await serverAdapter.handleNodeRequestAndResponse(req, reply, {
-    req: reply.request,
-    reply,
-  });
-
-  response.headers.forEach((value, key) => {
-    reply.header(key, value);
-  });
-
-  reply.status(response.status);
-
-  reply.send(response.body);
-
-  return reply;
-}
-
 describe('Fastify', () => {
   if (process.env.LEAK_TEST) {
     it('noop', () => {});
@@ -48,7 +27,11 @@ describe('Fastify', () => {
       fastifyServer.route({
         url: '/mypath',
         method: ['GET', 'POST', 'OPTIONS'],
-        handler: (req, reply) => handleFastify(serverAdapter, req, reply),
+        handler: (req, reply) =>
+          serverAdapter.handleNodeRequestAndResponse(req, reply, {
+            req,
+            reply,
+          }),
       });
       afterAll(() => fastifyServer.close());
       it('should handle streams', async () => {


### PR DESCRIPTION
Now the server adapter created with `@whatwg-node/server` can be used with Fastify easier;

```ts
import fastify, { FastifyReply, FastifyRequest } from 'fastify'
import myServerAdapter from './myServerAdapter'

// This is the fastify instance you have created
const app = fastify({ logger: true })

/**
 * We pass the incoming HTTP request to our adapter
 * and handle the response using Fastify's `reply` API
 * Learn more about `reply` https://www.fastify.io/docs/latest/Reply/
 **/
app.route({
  url: '/mypath',
  method: ['GET', 'POST', 'OPTIONS'],
  handler: (req, reply) => myServerAdapter.handleNodeRequestAndResponse(req, reply, {
      req,
      reply
    })
})

app.listen(4000)
```