### PR TITLE
fix(node-server): PonyfillBlob extends native Blob

### DIFF
--- a/.changeset/unlucky-donkeys-obey.md
+++ b/.changeset/unlucky-donkeys-obey.md
@@ -1,0 +1,14 @@
+---
+"@whatwg-node/node-fetch": patch
+---
+
+PonyfillBlob extends native Blob
+
+Now a Blob field can be checked against a native Blob implementation, _i.e._:
+
+```ts
+const body = new PonyfillBlob([])
+
+if (body instanceof Blob)
+  // ...
+```

--- a/packages/node-fetch/src/Blob.ts
+++ b/packages/node-fetch/src/Blob.ts
@@ -37,15 +37,14 @@ function isBlob(obj: any): obj is Blob {
 
 // Will be removed after v14 reaches EOL
 // Needed because v14 doesn't have .stream() implemented
-export class PonyfillBlob implements Blob {
-  type: string;
+export class PonyfillBlob extends Blob {
   private encoding: BufferEncoding;
   private _size: number | null = null;
   constructor(
     private blobParts: BlobPart[],
     options?: BlobOptions,
   ) {
-    this.type = options?.type || 'application/octet-stream';
+    super(blobParts, { type: options?.type || 'application/octet-stream' });
     this.encoding = options?.encoding || 'utf8';
     this._size = options?.size || null;
     if (blobParts.length === 1 && isBlob(blobParts[0])) {

--- a/packages/node-fetch/tests/Body.spec.ts
+++ b/packages/node-fetch/tests/Body.spec.ts
@@ -1,3 +1,4 @@
+import { Blob as NodeBlob } from 'buffer';
 import { Readable } from 'stream';
 import { PonyfillBlob } from '../src/Blob.js';
 import { PonyfillBody } from '../src/Body.js';
@@ -79,5 +80,9 @@ describe('Body', () => {
       }),
     );
     await expect(() => body.formData()).rejects.toThrow(TypeError);
+  });
+  it('PonyfillBlob is compatible with native Blob', () => {
+    const body = new PonyfillBlob([]);
+    expect(body instanceof NodeBlob).toBe(true);
   });
 });


### PR DESCRIPTION
based on [@tanker/file-ponyfill](https://www.npmjs.com/package/@tanker/file-ponyfill), i'd expect `PonyfillBlob instanceof Blob` to evaluate to true, but it doesn't work with this library.

it's troublesome for very specific cases. i found this issue while working with GraphQL using `graphql-yoga` (it uses `@whatwg-node/node-fetch` under the hood) and `type-graphql`:
- `graphql-yoga` receives the request and transforms it using `@whatwg-node/node-fetch`
- then the request is passed to `type-graphql`, which transforms the body into the Entity class defined by the user, checking if `data instanceof Target` (in this case, data = PonyfillBlob; Target = Blob). **error**