### PR TITLE
fix: Vary: Origin header overwritten

### DIFF
--- a/.changeset/real-bananas-visit.md
+++ b/.changeset/real-bananas-visit.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/server': patch
+---
+
+Vary: Access-Control-Request-Headers would overwrite Vary: Origin

--- a/packages/server/src/plugins/useCors.ts
+++ b/packages/server/src/plugins/useCors.ts
@@ -77,8 +77,9 @@ export function getCORSHeadersByRequestAndOptions(
       headers['Access-Control-Allow-Headers'] = requestHeaders;
       if (headers['Vary']) {
         headers['Vary'] += ', Access-Control-Request-Headers';
+      } else {
+        headers['Vary'] = 'Access-Control-Request-Headers';
       }
-      headers['Vary'] = 'Access-Control-Request-Headers';
     }
   }
 

--- a/packages/server/test/useCors.spec.ts
+++ b/packages/server/test/useCors.spec.ts
@@ -100,5 +100,22 @@ describe('CORS', () => {
         expect(headers?.['Access-Control-Allow-Origin']).toBeUndefined();
       });
     });
+    describe('Vary header', () => {
+      const corsOptionsWithMultipleOrigins: CORSOptions = {
+        origin: ['http://localhost:4000', 'http://localhost:4001'],
+      };
+      it('should return vary with multiple values', () => {
+        const request = new Request('http://localhost:4002/graphql', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            origin: 'http://localhost:4001',
+            'access-control-request-headers': 'x-foobar',
+          },
+        });
+        const headers = getCORSHeadersByRequestAndOptions(request, corsOptionsWithMultipleOrigins);
+        expect(headers?.Vary).toBe('Origin, Access-Control-Request-Headers');
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on WhatWG Node!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Reading the code, I stumbled on this code mistake where `Vary: Origin` would be overwritten by the `Vary: Access-Control-Request-Headers` because of a missing `else`.

Related # (issue)

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `package-name`:
- NodeJS:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
