### PR TITLE
feat(server): handle compression/decompression bodies

### DIFF
--- a/.changeset/lemon-coats-learn.md
+++ b/.changeset/lemon-coats-learn.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/node-fetch': patch
+---
+
+Send supported encoding formats in \`accept-encoding\` header by default

--- a/.changeset/olive-tigers-sort.md
+++ b/.changeset/olive-tigers-sort.md
@@ -1,0 +1,21 @@
+---
+'@whatwg-node/server': patch
+---
+
+New plugin to handle E2E request compression
+
+When the client provides `Accept-Encoding` header, if the server supports the encoding, it will compress the response body. This will reduce the size of the response body and improve the performance of the application. 
+
+On the other hand, if the client sends `Content-Encoding` header, the server will decompress the request body before processing it. This will allow the server to handle the request body in its original form. 
+If the server does not support the encoding, it will respond with `415 Unsupported Media Type` status code. 
+
+`serverAdapter`'s `fetch` function handles the compression and decompression of the request and response bodies. 
+
+```ts
+import {createServerAdapter, useContentEncoding, Response} from '@whatwg-node/server';
+
+const serverAdapter = createServerAdapter(() => Response.json({hello: 'world'}), {
+    plugins: [useContentEncoding()],
+});
+
+```

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write
     if:
       ${{ (github.event.pull_request.head.repo.full_name == github.repository ||
       github.event.inputs.onDemand == 'yes') && github.event.pull_request.title != 'Upcoming Release

--- a/packages/node-fetch/src/fetchNodeHttp.ts
+++ b/packages/node-fetch/src/fetchNodeHttp.ts
@@ -31,8 +31,12 @@ export function fetchNodeHttp<TResponseJSON = any, TRequestJSON = any>(
             : Readable.from(fetchRequest.body)
           : null
       ) as Readable | null;
-      const headersSerializer = (fetchRequest.headersSerializer as any) || getHeadersObj;
+      const headersSerializer: typeof getHeadersObj =
+        (fetchRequest.headersSerializer as any) || getHeadersObj;
       const nodeHeaders = headersSerializer(fetchRequest.headers);
+      if (nodeHeaders['accept-encoding'] == null) {
+        nodeHeaders['accept-encoding'] = 'gzip, deflate, br';
+      }
 
       const nodeRequest = requestFn(fetchRequest.url, {
         method: fetchRequest.method,

--- a/packages/server/src/createServerAdapter.ts
+++ b/packages/server/src/createServerAdapter.ts
@@ -18,6 +18,7 @@ import {
   completeAssign,
   handleAbortSignalAndPromiseResponse,
   handleErrorFromRequestHandler,
+  handleResponseDecompression,
   isFetchEvent,
   isNodeRequest,
   isolateObject,
@@ -131,6 +132,9 @@ function createServerAdapter<
             (onRequestHook, stopEarly) =>
               onRequestHook({
                 request,
+                setRequest(newRequest) {
+                  request = newRequest;
+                },
                 serverContext,
                 fetchAPI,
                 url,
@@ -154,6 +158,10 @@ function createServerAdapter<
               request,
               response,
               serverContext,
+              setResponse(newResponse) {
+                response = newResponse;
+              },
+              fetchAPI,
             };
             const onResponseHooksIteration$ = iterateAsyncVoid(onResponseHooks, onResponseHook =>
               onResponseHook(onResponseHookPayload),
@@ -335,18 +343,25 @@ function createServerAdapter<
     input,
     ...maybeCtx: Partial<TServerContext>[]
   ) => {
-    if (typeof input === 'string' || 'href' in input) {
-      const [initOrCtx, ...restOfCtx] = maybeCtx;
-      if (isRequestInit(initOrCtx)) {
-        const request = new fetchAPI.Request(input, initOrCtx);
-        const res$ = handleRequestWithWaitUntil(request, ...restOfCtx);
-        return handleAbortSignalAndPromiseResponse(res$, (initOrCtx as RequestInit)?.signal);
+    function getResponse() {
+      if (typeof input === 'string' || 'href' in input) {
+        const [initOrCtx, ...restOfCtx] = maybeCtx;
+        if (isRequestInit(initOrCtx)) {
+          const request = new fetchAPI.Request(input, initOrCtx);
+          const res$ = handleRequestWithWaitUntil(request, ...restOfCtx);
+          return handleAbortSignalAndPromiseResponse(res$, (initOrCtx as RequestInit)?.signal);
+        }
+        const request = new fetchAPI.Request(input);
+        return handleRequestWithWaitUntil(request, ...maybeCtx);
       }
-      const request = new fetchAPI.Request(input);
-      return handleRequestWithWaitUntil(request, ...maybeCtx);
+      const res$ = handleRequestWithWaitUntil(input, ...maybeCtx);
+      return handleAbortSignalAndPromiseResponse(res$, (input as any)._signal);
     }
-    const res$ = handleRequestWithWaitUntil(input, ...maybeCtx);
-    return handleAbortSignalAndPromiseResponse(res$, (input as any)._signal);
+    const res$ = getResponse();
+    if (isPromise(res$)) {
+      return res$.then(res => handleResponseDecompression(res, fetchAPI.Response));
+    }
+    return handleResponseDecompression(res$, fetchAPI.Response);
   };
 
   const genericRequestHandler = (

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,5 +4,6 @@ export * from './utils.js';
 export * from './plugins/types.js';
 export * from './plugins/useCors.js';
 export * from './plugins/useErrorHandling.js';
+export * from './plugins/useContentEncoding.js';
 export * from './uwebsockets.js';
 export { Response } from '@whatwg-node/fetch';

--- a/packages/server/src/plugins/types.ts
+++ b/packages/server/src/plugins/types.ts
@@ -11,6 +11,7 @@ export type OnRequestHook<TServerContext> = (
 
 export interface OnRequestEventPayload<TServerContext> {
   request: Request;
+  setRequest(newRequest: Request): void;
   serverContext: TServerContext | undefined;
   fetchAPI: FetchAPI;
   requestHandler: ServerAdapterRequestHandler<TServerContext>;
@@ -27,4 +28,6 @@ export interface OnResponseEventPayload<TServerContext> {
   request: Request;
   serverContext: TServerContext | undefined;
   response: Response;
+  setResponse(newResponse: Response): void;
+  fetchAPI: FetchAPI;
 }

--- a/packages/server/src/plugins/useContentEncoding.ts
+++ b/packages/server/src/plugins/useContentEncoding.ts
@@ -1,5 +1,5 @@
-import { decompressedResponseMap, SUPPORTED_ENCODINGS } from '../utils';
-import { ServerAdapterPlugin } from './types';
+import { decompressedResponseMap, SUPPORTED_ENCODINGS } from '../utils.js';
+import type { ServerAdapterPlugin } from './types.js';
 
 export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServerContext> {
   const encodingMap = new WeakMap<Request, string[]>();

--- a/packages/server/src/plugins/useContentEncoding.ts
+++ b/packages/server/src/plugins/useContentEncoding.ts
@@ -1,0 +1,68 @@
+import { decompressedResponseMap, SUPPORTED_ENCODINGS } from '../utils';
+import { ServerAdapterPlugin } from './types';
+
+export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServerContext> {
+  const encodingMap = new WeakMap<Request, string[]>();
+  return {
+    onRequest({ request, setRequest, fetchAPI, endResponse }) {
+      if (request.body) {
+        const contentEncodingHeader = request.headers.get('content-encoding');
+        if (contentEncodingHeader) {
+          const contentEncodings = contentEncodingHeader?.split(',');
+          if (
+            !contentEncodings.every(encoding =>
+              SUPPORTED_ENCODINGS.includes(encoding as CompressionFormat),
+            )
+          ) {
+            endResponse(
+              new fetchAPI.Response('Unsupported encoding: ' + contentEncodingHeader, {
+                status: 415,
+                statusText: 'Unsupported Media Type',
+              }),
+            );
+            return;
+          }
+          let newBody = request.body;
+          for (const contentEncoding of contentEncodings) {
+            newBody = newBody.pipeThrough(
+              new DecompressionStream(contentEncoding as CompressionFormat),
+            );
+          }
+          const newRequest = new fetchAPI.Request(request.url, {
+            ...request,
+            body: newBody,
+          });
+          setRequest(newRequest);
+        }
+      }
+      const acceptEncoding = request.headers.get('accept-encoding');
+      if (acceptEncoding) {
+        encodingMap.set(request, acceptEncoding.split(','));
+      }
+    },
+    onResponse({ request, response, setResponse, fetchAPI }) {
+      if (response.body) {
+        const encodings = encodingMap.get(request);
+        if (encodings) {
+          const supportedEncoding = encodings.find(encoding =>
+            SUPPORTED_ENCODINGS.includes(encoding as CompressionFormat),
+          );
+          if (supportedEncoding) {
+            const newHeaders = new fetchAPI.Headers(response.headers);
+            newHeaders.set('content-encoding', supportedEncoding);
+            newHeaders.delete('content-length');
+            const compressedBody = response.body.pipeThrough(
+              new CompressionStream(supportedEncoding as CompressionFormat),
+            );
+            const compressedResponse = new fetchAPI.Response(compressedBody, {
+              ...response,
+              headers: newHeaders,
+            });
+            decompressedResponseMap.set(compressedResponse, response);
+            setResponse(compressedResponse);
+          }
+        }
+      }
+    },
+  };
+}

--- a/packages/server/src/plugins/useContentEncoding.ts
+++ b/packages/server/src/plugins/useContentEncoding.ts
@@ -15,7 +15,7 @@ export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServe
             )
           ) {
             endResponse(
-              new fetchAPI.Response('Unsupported encoding: ' + contentEncodingHeader, {
+              new fetchAPI.Response(`Unsupported 'Content-Encoding': ${contentEncodingHeader}`, {
                 status: 415,
                 statusText: 'Unsupported Media Type',
               }),

--- a/packages/server/src/plugins/useContentEncoding.ts
+++ b/packages/server/src/plugins/useContentEncoding.ts
@@ -1,4 +1,4 @@
-import { decompressedResponseMap, SUPPORTED_ENCODINGS } from '../utils.js';
+import { decompressedResponseMap, getSupportedEncodings } from '../utils.js';
 import type { ServerAdapterPlugin } from './types.js';
 
 export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServerContext> {
@@ -11,7 +11,7 @@ export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServe
           const contentEncodings = contentEncodingHeader?.split(',');
           if (
             !contentEncodings.every(encoding =>
-              SUPPORTED_ENCODINGS.includes(encoding as CompressionFormat),
+              getSupportedEncodings().includes(encoding as CompressionFormat),
             )
           ) {
             endResponse(
@@ -45,7 +45,7 @@ export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServe
         const encodings = encodingMap.get(request);
         if (encodings) {
           const supportedEncoding = encodings.find(encoding =>
-            SUPPORTED_ENCODINGS.includes(encoding as CompressionFormat),
+            getSupportedEncodings().includes(encoding as CompressionFormat),
           );
           if (supportedEncoding) {
             const newHeaders = new fetchAPI.Headers(response.headers);

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -596,7 +596,8 @@ let SUPPORTED_ENCODINGS: CompressionFormat[];
 
 export function getSupportedEncodings() {
   if (!SUPPORTED_ENCODINGS) {
-    const possibleEncodings: CompressionFormat[] = ['deflate', 'deflate-raw', 'gzip'];
+    // TODO: deflate-raw is buggy in Node.js
+    const possibleEncodings: CompressionFormat[] = ['deflate', 'gzip' /* 'deflate-raw' */];
     SUPPORTED_ENCODINGS = possibleEncodings.filter(encoding => {
       try {
         // eslint-disable-next-line no-new
@@ -623,7 +624,7 @@ export function handleResponseDecompression(response: Response, ResponseCtor: ty
     let decompressedBody = response.body;
     const contentEncodings = contentEncodingHeader.split(',');
     if (
-      !contentEncodings?.every(encoding =>
+      !contentEncodings.every(encoding =>
         getSupportedEncodings().includes(encoding as CompressionFormat),
       )
     ) {

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -595,7 +595,7 @@ export const decompressedResponseMap = new WeakMap<Response, Response>();
 export const SUPPORTED_ENCODINGS: CompressionFormat[] = ['deflate', 'gzip'];
 
 export function handleResponseDecompression(response: Response, ResponseCtor: typeof Response) {
-  const contentEncodingHeader = response.headers.get('content-encoding');
+  const contentEncodingHeader = response?.headers.get('content-encoding');
   if (!contentEncodingHeader) {
     return response;
   }

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -595,7 +595,7 @@ export const decompressedResponseMap = new WeakMap<Response, Response>();
 export const SUPPORTED_ENCODINGS: CompressionFormat[] = ['deflate', 'gzip'];
 
 export function handleResponseDecompression(response: Response, ResponseCtor: typeof Response) {
-  if (!response.body) {
+  if (!response?.body) {
     return response;
   }
   const contentEncodingHeader = response.headers.get('content-encoding');

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -595,11 +595,11 @@ export const decompressedResponseMap = new WeakMap<Response, Response>();
 export const SUPPORTED_ENCODINGS: CompressionFormat[] = ['deflate', 'gzip'];
 
 export function handleResponseDecompression(response: Response, ResponseCtor: typeof Response) {
-  if (!response?.body) {
-    return response;
-  }
   const contentEncodingHeader = response.headers.get('content-encoding');
   if (!contentEncodingHeader) {
+    return response;
+  }
+  if (!response?.body) {
     return response;
   }
   let decompressedResponse = decompressedResponseMap.get(response);

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -611,7 +611,7 @@ export function handleResponseDecompression(response: Response, ResponseCtor: ty
         SUPPORTED_ENCODINGS.includes(encoding as CompressionFormat),
       )
     ) {
-      return new ResponseCtor('Unsupported encoding' + contentEncodingHeader, {
+      return new ResponseCtor(`Unsupported 'Content-Encoding': ${contentEncodingHeader}`, {
         status: 415,
         statusText: 'Unsupported Media Type',
       });

--- a/packages/server/test/compression.spec.ts
+++ b/packages/server/test/compression.spec.ts
@@ -1,0 +1,106 @@
+import { useContentEncoding } from '../src/plugins/useContentEncoding';
+import { SUPPORTED_ENCODINGS } from '../src/utils';
+import { runTestsForEachFetchImpl } from './test-fetch';
+import { runTestsForEachServerImpl } from './test-server';
+
+describe('Compression', () => {
+  const exampleData = JSON.stringify({
+    hello: 'world',
+  });
+  describe('Adapter', () => {
+    runTestsForEachFetchImpl(
+      (_, { fetchAPI, createServerAdapter }) => {
+        for (const encoding of SUPPORTED_ENCODINGS) {
+          describe(encoding, () => {
+            it('from the server to the client', async () => {
+              const adapter = createServerAdapter(() => new fetchAPI.Response(exampleData), {
+                plugins: [useContentEncoding()],
+              });
+              const res = await adapter.fetch('/', {
+                headers: {
+                  'accept-encoding': encoding,
+                },
+              });
+              expect(res.status).toEqual(200);
+              await expect(res.text()).resolves.toEqual(exampleData);
+            });
+            it('from the client to the server', async () => {
+              const adapter = createServerAdapter(
+                async req => {
+                  const body = await req.text();
+                  return new fetchAPI.Response(body);
+                },
+                {
+                  plugins: [useContentEncoding()],
+                },
+              );
+              const stream = new CompressionStream(encoding);
+              const writer = stream.writable.getWriter();
+              writer.write(exampleData);
+              writer.close();
+              const res = await adapter.fetch('/', {
+                method: 'POST',
+                headers: {
+                  'content-encoding': encoding,
+                },
+                body: stream.readable,
+                duplex: 'half',
+              });
+              await expect(res.text()).resolves.toEqual(exampleData);
+            });
+          });
+        }
+      },
+      { noLibCurl: true },
+    );
+  });
+  runTestsForEachFetchImpl((_, { fetchAPI, createServerAdapter }) => {
+    runTestsForEachServerImpl(server => {
+      for (const encoding of SUPPORTED_ENCODINGS) {
+        describe(encoding, () => {
+          it(`from the server to the client`, async () => {
+            const adapter = createServerAdapter(() => new fetchAPI.Response(exampleData), {
+              plugins: [useContentEncoding()],
+            });
+            server.addOnceHandler(adapter);
+            const res = await fetchAPI.fetch(server.url, {
+              headers: {
+                'accept-encoding': encoding,
+              },
+            });
+            expect(res.headers.get('content-encoding')).toEqual(encoding);
+            expect(res.status).toEqual(200);
+            await expect(res.text()).resolves.toEqual(exampleData);
+          });
+          it(`from the client to the server`, async () => {
+            const adapter = createServerAdapter(
+              async req => {
+                const body = await req.text();
+                return new fetchAPI.Response(body);
+              },
+              {
+                plugins: [useContentEncoding()],
+              },
+            );
+            server.addOnceHandler(adapter);
+            const stream = new CompressionStream(encoding);
+            const writer = stream.writable.getWriter();
+            writer.write(exampleData);
+            writer.close();
+            const res = await fetchAPI.fetch(server.url, {
+              method: 'POST',
+              headers: {
+                'content-encoding': encoding,
+              },
+              body: stream.readable,
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore - not in the types yet
+              duplex: 'half',
+            });
+            await expect(res.text()).resolves.toEqual(exampleData);
+          });
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
New plugin to handle E2E request compression

When the client provides `Accept-Encoding` header, if the server supports the encoding, it will compress the response body. This will reduce the size of the response body and improve the performance of the application. 

On the other hand, if the client sends `Content-Encoding` header, the server will decompress the request body before processing it. This will allow the server to handle the request body in its original form. 
If the server does not support the encoding, it will respond with `415 Unsupported Media Type` status code. 

`serverAdapter`'s `fetch` function handles the compression and decompression of the request and response bodies. 

```ts
import {createServerAdapter, useContentEncoding, Response} from '@whatwg-node/server';

const serverAdapter = createServerAdapter(() => Response.json({hello: 'world'}), {
    plugins: [useContentEncoding()],
});

```