### PR TITLE
enhance(node-fetch): respect Node SSL-related env vars

### DIFF
--- a/.changeset/ninety-pigs-bathe.md
+++ b/.changeset/ninety-pigs-bathe.md
@@ -1,0 +1,9 @@
+---
+'@whatwg-node/node-fetch': patch
+---
+
+When cURL is used as the HTTP client implementation instead of node:http,
+`SSL_VERIFYPEER` should be set `false` when the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable is set to `0`.
+`CAINFO` should be set to the value of the `NODE_EXTRA_CA_CERTS` environment variable.
+
+This allows the cURL client to use the same CA certificates and SSL configuration as `node:http`

--- a/.changeset/young-dancers-nail.md
+++ b/.changeset/young-dancers-nail.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/node-fetch': patch
+---
+
+When `agent` is provided in `Request`, use `node:http` instead of `node-libcurl`

--- a/packages/node-fetch/src/Request.ts
+++ b/packages/node-fetch/src/Request.ts
@@ -1,5 +1,5 @@
-import { Agent as HTTPAgent, globalAgent as httpGlobalAgent } from 'http';
-import { Agent as HTTPSAgent, globalAgent as httpsGlobalAgent } from 'https';
+import { Agent as HTTPAgent } from 'http';
+import { Agent as HTTPSAgent } from 'https';
 import { BodyPonyfillInit, PonyfillBody, PonyfillBodyOptions } from './Body.js';
 import { isHeadersLike, PonyfillHeaders, PonyfillHeadersInit } from './Headers.js';
 
@@ -77,11 +77,11 @@ export class PonyfillRequest<TJSON = any> extends PonyfillBody<TJSON> implements
 
     if (requestInit?.agent != null) {
       if (requestInit.agent === false) {
-        this._agent = false;
+        this.agent = false;
       } else if (this.url.startsWith('http:/') && requestInit.agent instanceof HTTPAgent) {
-        this._agent = requestInit?.agent;
+        this.agent = requestInit.agent;
       } else if (this.url.startsWith('https:/') && requestInit.agent instanceof HTTPSAgent) {
-        this._agent = requestInit?.agent;
+        this.agent = requestInit.agent;
       }
     }
   }
@@ -102,22 +102,7 @@ export class PonyfillRequest<TJSON = any> extends PonyfillBody<TJSON> implements
   url: string;
   duplex: 'half' | 'full';
 
-  private _agent: HTTPAgent | HTTPSAgent | false | undefined;
-
-  get agent() {
-    if (this._agent != null) {
-      return this._agent;
-    }
-    // Disable agent when running in jest
-    if (globalThis['libcurl'] || typeof jest === 'object') {
-      return false;
-    }
-    if (this.url.startsWith('http:')) {
-      return httpGlobalAgent;
-    } else if (this.url.startsWith('https:')) {
-      return httpsGlobalAgent;
-    }
-  }
+  agent: HTTPAgent | HTTPSAgent | false | undefined;
 
   private _signal: AbortSignal | undefined | null;
 

--- a/packages/node-fetch/src/fetch.ts
+++ b/packages/node-fetch/src/fetch.ts
@@ -78,7 +78,7 @@ export function fetchPonyfill<TResponseJSON = any, TRequestJSON = any>(
     const response = getResponseForBlob(fetchRequest.url);
     return fakePromise(response);
   }
-  if (globalThis.libcurl) {
+  if (globalThis.libcurl && !fetchRequest.agent) {
     return fetchCurl(fetchRequest);
   }
   return fetchNodeHttp(fetchRequest);

--- a/packages/node-fetch/src/fetchCurl.ts
+++ b/packages/node-fetch/src/fetchCurl.ts
@@ -14,7 +14,13 @@ export function fetchCurl<TResponseJSON = any, TRequestJSON = any>(
 
   curlHandle.setOpt('URL', fetchRequest.url);
 
-  curlHandle.setOpt('SSL_VERIFYPEER', false);
+  if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0') {
+    curlHandle.setOpt('SSL_VERIFYPEER', false);
+  }
+
+  if (process.env.NODE_EXTRA_CA_CERTS) {
+    curlHandle.setOpt('CAINFO', process.env.NODE_EXTRA_CA_CERTS);
+  }
 
   curlHandle.enable(CurlFeature.StreamResponse);
 

--- a/packages/node-fetch/tests/http2.spec.ts
+++ b/packages/node-fetch/tests/http2.spec.ts
@@ -1,5 +1,5 @@
 import { promises as fsPromises } from 'fs';
-import { createSecureServer, type Http2SecureServer } from 'http2';
+import { createSecureServer, ServerHttp2Session, type Http2SecureServer } from 'http2';
 import { AddressInfo } from 'net';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -12,7 +12,9 @@ describe('http2', () => {
     return;
   }
   let server: Http2SecureServer;
+  let pemPath: string;
   const oldEnvVar = process.env.NODE_EXTRA_CA_CERTS;
+  const sessions = new Set<ServerHttp2Session>();
   beforeAll(async () => {
     const keys = await new Promise<CertificateCreationResult>((resolve, reject) => {
       createCertificate(
@@ -28,7 +30,7 @@ describe('http2', () => {
         },
       );
     });
-    const pemPath = join(tmpdir(), 'test.pem');
+    pemPath = join(tmpdir(), 'test.pem');
     process.env.NODE_EXTRA_CA_CERTS = pemPath;
     await fsPromises.writeFile(pemPath, keys.certificate);
     // Create a secure HTTP/2 server
@@ -46,11 +48,19 @@ describe('http2', () => {
       },
     );
 
+    server.on('session', session => {
+      sessions.add(session);
+    });
+
     await new Promise<void>(resolve => server.listen(0, resolve));
   });
-  afterAll(() => {
+  afterAll(async () => {
+    await fsPromises.unlink(pemPath);
     process.env.NODE_EXTRA_CA_CERTS = oldEnvVar;
-    server.close();
+    for (const session of sessions) {
+      session.destroy();
+    }
+    await new Promise(resolve => server.close(resolve));
   });
   it('works', async () => {
     const res = await fetchPonyfill(`https://localhost:${(server.address() as AddressInfo).port}`, {

--- a/packages/node-fetch/tests/http2.spec.ts
+++ b/packages/node-fetch/tests/http2.spec.ts
@@ -1,5 +1,8 @@
+import { promises as fsPromises } from 'fs';
 import { createSecureServer, type Http2SecureServer } from 'http2';
 import { AddressInfo } from 'net';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { CertificateCreationResult, createCertificate } from 'pem';
 import { fetchPonyfill } from '../src/fetch';
 
@@ -9,6 +12,7 @@ describe('http2', () => {
     return;
   }
   let server: Http2SecureServer;
+  const oldEnvVar = process.env.NODE_EXTRA_CA_CERTS;
   beforeAll(async () => {
     const keys = await new Promise<CertificateCreationResult>((resolve, reject) => {
       createCertificate(
@@ -24,6 +28,9 @@ describe('http2', () => {
         },
       );
     });
+    const pemPath = join(tmpdir(), 'test.pem');
+    process.env.NODE_EXTRA_CA_CERTS = pemPath;
+    await fsPromises.writeFile(pemPath, keys.certificate);
     // Create a secure HTTP/2 server
     server = createSecureServer(
       {
@@ -42,6 +49,7 @@ describe('http2', () => {
     await new Promise<void>(resolve => server.listen(0, resolve));
   });
   afterAll(() => {
+    process.env.NODE_EXTRA_CA_CERTS = oldEnvVar;
     server.close();
   });
   it('works', async () => {

--- a/packages/server/test/test-fetch.ts
+++ b/packages/server/test/test-fetch.ts
@@ -1,4 +1,6 @@
 /* eslint-disable n/no-callback-literal */
+import { globalAgent as httpGlobalAgent } from 'http';
+import { globalAgent as httpsGlobalAgent } from 'https';
 import type { Dispatcher } from 'undici';
 import { createFetch } from '@whatwg-node/fetch';
 import { createServerAdapter } from '../src/createServerAdapter';
@@ -49,6 +51,8 @@ export function runTestsForEachFetchImpl(
         (globalThis.libcurl as any) = null;
       });
       afterAll(() => {
+        httpGlobalAgent.destroy();
+        httpsGlobalAgent.destroy();
         globalThis.libcurl = libcurl;
       });
       const fetchAPI = createFetch({ skipPonyfill: false });


### PR DESCRIPTION
When cURL is used as the HTTP client implementation instead of node:http,
`SSL_VERIFYPEER` should be set `false` when the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable is set to `0`.
`CAINFO` should be set to the value of the `NODE_EXTRA_CA_CERTS` environment variable.

This allows the cURL client to use the same CA certificates and SSL configuration as `node:http`