### PR TITLE
fix(fetchPolyfill): skip if fetch is already present in the global scope

### DIFF
--- a/packages/fetch/dist/shouldSkipPonyfill.js
+++ b/packages/fetch/dist/shouldSkipPonyfill.js
@@ -4,6 +4,9 @@ function isNextJs() {
 }
 
 module.exports = function shouldSkipPonyfill() {
+  if (typeof globalThis.fetch === 'function') {
+    return true
+  }
   // Bun and Deno already have a Fetch API
   if (globalThis.Deno) {
     return true
@@ -12,9 +15,6 @@ module.exports = function shouldSkipPonyfill() {
     return true
   }
   if (isNextJs()) {
-    return true
-  }
-  if (typeof globalThis.fetch === 'function') {
     return true
   }
   return false

--- a/packages/fetch/dist/shouldSkipPonyfill.js
+++ b/packages/fetch/dist/shouldSkipPonyfill.js
@@ -14,5 +14,8 @@ module.exports = function shouldSkipPonyfill() {
   if (isNextJs()) {
     return true
   }
+  if (typeof globalThis.fetch === 'function') {
+    return true
+  }
   return false
 }


### PR DESCRIPTION
Hey @ardatan 

This package is used by another package I am using inside of a Cloudflare worker and trying to Polyfll the fetch API does not work due to Cloudflare workers only having a subset of the Node APIs.

Was hoping to include this code change to get it working - was also thinking maybe with this change the checks for Deno and bun could be removed (although I'm not familiar with the code base so maybe not).

Would be great to get your thoughts.