### PR TITLE
New ponyfills AbortSignal and AbortController

### DIFF
--- a/.changeset/rich-bags-grow.md
+++ b/.changeset/rich-bags-grow.md
@@ -1,0 +1,6 @@
+---
+'@whatwg-node/node-fetch': minor
+'@whatwg-node/fetch': minor
+---
+
+New ponyfills \`AbortSignal\` and \`AbortController\`

--- a/packages/fetch/dist/create-node-ponyfill.js
+++ b/packages/fetch/dist/create-node-ponyfill.js
@@ -34,7 +34,9 @@ module.exports = function createNodePonyfill(opts = {}) {
       TextDecoder: globalThis.TextDecoder,
       URLPattern: ponyfills.URLPattern,
       URL: globalThis.URL,
-      URLSearchParams: globalThis.URLSearchParams
+      URLSearchParams: globalThis.URLSearchParams,
+      AbortController: globalThis.AbortController,
+      AbortSignal: globalThis.AbortSignal,
     };
   }
 
@@ -63,6 +65,8 @@ module.exports = function createNodePonyfill(opts = {}) {
   ponyfills.btoa = newNodeFetch.btoa;
   ponyfills.TextEncoder = newNodeFetch.TextEncoder;
   ponyfills.TextDecoder = newNodeFetch.TextDecoder;
+  ponyfills.AbortController = newNodeFetch.AbortController;
+  ponyfills.AbortSignal = newNodeFetch.AbortSignal;
 
   if (opts.formDataLimits) {
     ponyfills.Body = class Body extends newNodeFetch.Body {

--- a/packages/fetch/dist/esm-ponyfill.js
+++ b/packages/fetch/dist/esm-ponyfill.js
@@ -19,6 +19,8 @@ const TextDecoder = globalThis.TextDecoder;
 const URLPattern = globalThis.URLPattern;
 const URL = globalThis.URL;
 const URLSearchParams = globalThis.URLSearchParams;
+const AbortController = globalThis.AbortController;
+const AbortSignal = globalThis.AbortSignal;
 
 export {
     fetch,
@@ -41,7 +43,9 @@ export {
     TextDecoder,
     URLPattern,
     URL,
-    URLSearchParams
+    URLSearchParams,
+    AbortController,
+        AbortSignal,
 }
 
 export function createFetch() {
@@ -64,6 +68,8 @@ export function createFetch() {
         TextDecoder,
         URLPattern,
         URL,
-        URLSearchParams
+        URLSearchParams,
+        AbortController,
+        AbortSignal,
     };
 }

--- a/packages/fetch/dist/global-ponyfill.js
+++ b/packages/fetch/dist/global-ponyfill.js
@@ -19,4 +19,6 @@ module.exports.TextDecoder = globalThis.TextDecoder;
 module.exports.URLPattern = globalThis.URLPattern;
 module.exports.URL = globalThis.URL;
 module.exports.URLSearchParams = globalThis.URLSearchParams;
+module.exports.AbortController = globalThis.AbortController;
+module.exports.AbortSignal = globalThis.AbortSignal;
 module.exports.createFetch = () => globalThis;

--- a/packages/fetch/dist/index.d.ts
+++ b/packages/fetch/dist/index.d.ts
@@ -28,6 +28,8 @@ declare module '@whatwg-node/fetch' {
   export const URL: typeof globalThis.URL;
   export const URLSearchParams: typeof globalThis.URLSearchParams;
   export const URLPattern: _URLPattern;
+  export const AbortController: typeof globalThis.AbortController;
+  export const AbortSignal: typeof globalThis.AbortSignal;
   export interface FormDataLimits {
     /* Max field name size (in bytes). Default: 100. */
     fieldNameSize?: number;
@@ -70,5 +72,7 @@ declare module '@whatwg-node/fetch' {
     URLPattern: typeof URLPattern;
     URL: typeof URL;
     URLSearchParams: typeof URLSearchParams;
+    AbortController: typeof AbortController;
+    AbortSignal: typeof AbortSignal;
   };
 }

--- a/packages/fetch/dist/node-ponyfill.js
+++ b/packages/fetch/dist/node-ponyfill.js
@@ -31,5 +31,7 @@ module.exports.TextDecoder = ponyfills.TextDecoder;
 module.exports.URLPattern = ponyfills.URLPattern;
 module.exports.URL = ponyfills.URL;
 module.exports.URLSearchParams = ponyfills.URLSearchParams;
+module.exports.AbortController = ponyfills.AbortController;
+module.exports.AbortSignal = ponyfills.AbortSignal;
 
 exports.createFetch = createNodePonyfill;

--- a/packages/node-fetch/src/AbortController.ts
+++ b/packages/node-fetch/src/AbortController.ts
@@ -1,0 +1,17 @@
+import { DisposableSymbols } from '@whatwg-node/disposablestack';
+import { PonyfillAbortSignal } from './AbortSignal.js';
+
+export class PonyfillAbortController implements AbortController {
+  signal: PonyfillAbortSignal;
+  constructor() {
+    this.signal = new PonyfillAbortSignal();
+  }
+
+  abort(reason?: any) {
+    return this.signal.sendAbort(reason);
+  }
+
+  [DisposableSymbols.dispose]() {
+    return this.abort();
+  }
+}

--- a/packages/node-fetch/src/AbortError.ts
+++ b/packages/node-fetch/src/AbortError.ts
@@ -1,11 +1,6 @@
 export class PonyfillAbortError extends DOMException {
-  constructor(reason?: any) {
-    let message = 'The operation was aborted';
-    if (reason) {
-      message += ` reason: ${reason}`;
-    }
-    super(message, 'AbortError');
-    this.cause = reason;
+  constructor() {
+    super('The operation was aborted', 'AbortError');
   }
 
   get reason() {

--- a/packages/node-fetch/src/AbortError.ts
+++ b/packages/node-fetch/src/AbortError.ts
@@ -1,13 +1,11 @@
-export class PonyfillAbortError extends Error {
+export class PonyfillAbortError extends DOMException {
   constructor(reason?: any) {
     let message = 'The operation was aborted';
     if (reason) {
       message += ` reason: ${reason}`;
     }
-    super(message, {
-      cause: reason,
-    });
-    this.name = 'AbortError';
+    super(message, 'AbortError');
+    this.cause = reason;
   }
 
   get reason() {

--- a/packages/node-fetch/src/AbortSignal.ts
+++ b/packages/node-fetch/src/AbortSignal.ts
@@ -1,0 +1,84 @@
+import { DisposableSymbols } from '@whatwg-node/disposablestack';
+import { PonyfillAbortError } from './AbortError';
+
+export class PonyfillAbortSignal extends EventTarget implements AbortSignal {
+  aborted = false;
+  private _onabort: ((this: AbortSignal, ev: Event) => any) | null = null;
+  reason: any;
+
+  constructor(...signals: PonyfillAbortSignal[]) {
+    super();
+    if (signals.length) {
+      return this.any(signals);
+    }
+  }
+
+  throwIfAborted(): void {
+    if (this.aborted) {
+      throw this.reason;
+    }
+  }
+
+  sendAbort(reason?: any) {
+    if (!this.aborted) {
+      this.reason = reason || new PonyfillAbortError();
+      this.aborted = true;
+      const event = new Event('abort');
+      this.dispatchEvent(event);
+    }
+  }
+
+  get onabort() {
+    return this._onabort;
+  }
+
+  set onabort(value) {
+    this._onabort = value;
+    if (value) {
+      this.addEventListener('abort', value);
+    } else {
+      this.removeEventListener('abort', value);
+    }
+  }
+
+  any(signals: Iterable<PonyfillAbortSignal>): PonyfillAbortSignal {
+    function onAbort(this: PonyfillAbortSignal, ev: Event) {
+      const signal = (ev.target as AbortSignal) || this;
+      this.sendAbort(signal.reason);
+      for (const signal of signals) {
+        signal.removeEventListener('abort', onAbort);
+        signal.reason = this.reason;
+        if (signal.sendAbort) {
+          signal.sendAbort(this.reason);
+        }
+        signal.aborted = true;
+      }
+    }
+    for (const signal of signals) {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+    return this;
+  }
+
+  static timeout(ms: number): AbortSignal {
+    const signal = new PonyfillAbortSignal();
+    const timeout = setTimeout(() => {
+      signal.sendAbort();
+      signal.removeEventListener('abort', onAbort);
+    }, ms);
+    function onAbort() {
+      clearTimeout(timeout);
+      signal.removeEventListener('abort', onAbort);
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+    return signal;
+  }
+
+  static any(signals: Iterable<PonyfillAbortSignal>): PonyfillAbortSignal {
+    return new PonyfillAbortSignal(...signals);
+  }
+
+  [DisposableSymbols.dispose]() {
+    return this.sendAbort();
+  }
+}

--- a/packages/node-fetch/src/AbortSignal.ts
+++ b/packages/node-fetch/src/AbortSignal.ts
@@ -1,5 +1,5 @@
 import { DisposableSymbols } from '@whatwg-node/disposablestack';
-import { PonyfillAbortError } from './AbortError';
+import { PonyfillAbortError } from './AbortError.js';
 
 export class PonyfillAbortSignal extends EventTarget implements AbortSignal {
   aborted = false;

--- a/packages/node-fetch/src/Request.ts
+++ b/packages/node-fetch/src/Request.ts
@@ -1,5 +1,6 @@
 import { Agent as HTTPAgent } from 'http';
 import { Agent as HTTPSAgent } from 'https';
+import { PonyfillAbortController } from './AbortController.js';
 import { BodyPonyfillInit, PonyfillBody, PonyfillBodyOptions } from './Body.js';
 import { isHeadersLike, PonyfillHeaders, PonyfillHeadersInit } from './Headers.js';
 import { PonyfillURL } from './URL.js';
@@ -143,7 +144,7 @@ export class PonyfillRequest<TJSON = any> extends PonyfillBody<TJSON> implements
     // Create a new signal only if needed
     // Because the creation of signal is expensive
     if (!this._signal) {
-      this._signal = new AbortController().signal;
+      this._signal = new PonyfillAbortController().signal;
     }
     return this._signal!;
   }

--- a/packages/node-fetch/src/WritableStream.ts
+++ b/packages/node-fetch/src/WritableStream.ts
@@ -77,7 +77,7 @@ export class PonyfillWritableStream<W = any> implements WritableStream<W> {
             }
             onabort = value;
             if (onabort) {
-              this.addEventListener('abort', onabort);
+              this.addEventListener('abort', onabort, { once: true });
             }
           },
           throwIfAborted() {

--- a/packages/node-fetch/src/fetchCurl.ts
+++ b/packages/node-fetch/src/fetchCurl.ts
@@ -130,6 +130,24 @@ export function fetchCurl<TResponseJSON = any, TRequestJSON = any>(
           }
         })
         .catch(deferredPromise.reject);
+
+      if (fetchRequest['_signal']) {
+        outputStream.once('error', () => {
+          if (!fetchRequest['_signal']?.aborted) {
+            (fetchRequest['_signal'] as any)?.sendAbort?.();
+          }
+        });
+        outputStream.once('close', () => {
+          if (!fetchRequest['_signal']?.aborted) {
+            (fetchRequest['_signal'] as any)?.sendAbort?.();
+          }
+        });
+        outputStream.once('destroy', () => {
+          if (!fetchRequest['_signal']?.aborted) {
+            (fetchRequest['_signal'] as any)?.sendAbort?.();
+          }
+        });
+      }
       const headersFlat = headersBuf
         .toString('utf8')
         .split(/\r?\n|\r/g)

--- a/packages/node-fetch/src/fetchNodeHttp.ts
+++ b/packages/node-fetch/src/fetchNodeHttp.ts
@@ -124,6 +124,24 @@ export function fetchNodeHttp<TResponseJSON = any, TRequestJSON = any>(
           })
           .catch(reject);
 
+        if (fetchRequest['_signal']) {
+          outputStream.once('error', () => {
+            if (!fetchRequest['_signal']?.aborted) {
+              (fetchRequest['_signal'] as any)?.sendAbort?.();
+            }
+          });
+          outputStream.once('close', () => {
+            if (!fetchRequest['_signal']?.aborted) {
+              (fetchRequest['_signal'] as any)?.sendAbort?.();
+            }
+          });
+          outputStream.once('destroy', () => {
+            if (!fetchRequest['_signal']?.aborted) {
+              (fetchRequest['_signal'] as any)?.sendAbort?.();
+            }
+          });
+        }
+
         const ponyfillResponse = new PonyfillResponse(outputStream, {
           status: nodeResponse.statusCode,
           statusText: nodeResponse.statusMessage,

--- a/packages/node-fetch/src/index.ts
+++ b/packages/node-fetch/src/index.ts
@@ -26,3 +26,6 @@ export {
   PonyfillTextDecoderStream as TextDecoderStream,
   PonyfillTextEncoderStream as TextEncoderStream,
 } from './TextEncoderDecoderStream.js';
+export { PonyfillAbortController as AbortController } from './AbortController.js';
+export { PonyfillAbortSignal as AbortSignal } from './AbortSignal.js';
+export { PonyfillAbortError as AbortError } from './AbortError.js';

--- a/packages/node-fetch/tests/AbortSignal.spec.ts
+++ b/packages/node-fetch/tests/AbortSignal.spec.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'timers/promises';
 import { PonyfillAbortController } from '../src/AbortController';
 import { PonyfillAbortSignal } from '../src/AbortSignal';
 
@@ -16,5 +17,14 @@ describe('AbortSignal', () => {
     expect(ev).toBeDefined();
     expect(ev?.type).toBe('abort');
     expect(ev?.target).toBe(combinedSignal);
+  });
+  it('timeout', async () => {
+    const signal = PonyfillAbortSignal.timeout(100);
+    expect(signal.aborted).toBe(false);
+    await setTimeout(200);
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toBeInstanceOf(DOMException);
+    expect(signal.reason.name).toBe('TimeoutError');
+    expect(signal.reason.message).toBe('The operation timed out.');
   });
 });

--- a/packages/node-fetch/tests/AbortSignal.spec.ts
+++ b/packages/node-fetch/tests/AbortSignal.spec.ts
@@ -1,0 +1,20 @@
+import { PonyfillAbortController } from '../src/AbortController';
+import { PonyfillAbortSignal } from '../src/AbortSignal';
+
+describe('AbortSignal', () => {
+  it('any', () => {
+    const ctrl1 = new PonyfillAbortController();
+    const ctrl2 = new PonyfillAbortController();
+    const combinedSignal = PonyfillAbortSignal.any([ctrl1.signal, ctrl2.signal]);
+    let ev: Event | undefined;
+    combinedSignal.addEventListener('abort', e => {
+      ev = e;
+    });
+    ctrl1.abort('reason1');
+    expect(combinedSignal.aborted).toBe(true);
+    expect(combinedSignal.reason).toBe('reason1');
+    expect(ev).toBeDefined();
+    expect(ev?.type).toBe('abort');
+    expect(ev?.target).toBe(combinedSignal);
+  });
+});

--- a/packages/node-fetch/tests/ReadableStream.spec.ts
+++ b/packages/node-fetch/tests/ReadableStream.spec.ts
@@ -1,4 +1,5 @@
 import { setTimeout } from 'timers/promises';
+import { PonyfillAbortController } from '../src/AbortController.js';
 import { PonyfillReadableStream } from '../src/ReadableStream.js';
 
 describe('ReadableStream', () => {
@@ -33,7 +34,7 @@ describe('ReadableStream', () => {
   });
   it('should send data from start and push lazily', async () => {
     let interval: any;
-    const timeoutSignal = new AbortController();
+    const timeoutSignal = new PonyfillAbortController();
     let pullCount = 0;
     let active: boolean;
     const rs = new PonyfillReadableStream({

--- a/packages/node-fetch/tests/fetch.spec.ts
+++ b/packages/node-fetch/tests/fetch.spec.ts
@@ -9,6 +9,22 @@ function testIf(condition: boolean, name: string, fn: () => void) {
 }
 
 describe('Node Fetch Ponyfill', () => {
+  let baseUrl: string;
+  beforeAll(async () => {
+    try {
+      const res = await fetch('http://localhost:8888');
+      const body = await res.text();
+      if (!body.includes('httpbin')) {
+        throw new Error('Server not running');
+      }
+      if (!res.ok) {
+        throw new Error('Server not running');
+      }
+      baseUrl = 'http://localhost:8888';
+    } catch (err) {
+      baseUrl = 'https://httpbin.org';
+    }
+  });
   runTestsForEachFetchImpl(
     (
       implName,
@@ -19,10 +35,11 @@ describe('Node Fetch Ponyfill', () => {
           ReadableStream: PonyfillReadableStream,
           FormData: PonyfillFormData,
           Blob: PonyfillBlob,
+          AbortController,
+          AbortSignal,
         },
       },
     ) => {
-      const baseUrl = process.env.CI ? 'http://localhost:8888' : 'https://httpbin.org';
       it('should fetch', async () => {
         const response = await fetchPonyfill(baseUrl + '/get');
         expect(response.status).toBe(200);

--- a/packages/server/src/createServerAdapter.ts
+++ b/packages/server/src/createServerAdapter.ts
@@ -307,7 +307,7 @@ function createServerAdapter<
       ctrl.abort();
     });
     res.onAborted = function (cb: () => void) {
-      ctrl.signal.addEventListener('abort', cb);
+      ctrl.signal.addEventListener('abort', cb, { once: true });
     };
     const request = getRequestFromUWSRequest({
       req,

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -531,9 +531,13 @@ export function handleAbortSignalAndPromiseResponse(
 ) {
   if (isPromise(response$) && abortSignal) {
     const deferred$ = createDeferredPromise<Response>();
-    abortSignal.addEventListener('abort', function abortSignalFetchErrorHandler() {
-      deferred$.reject(abortSignal.reason);
-    });
+    abortSignal.addEventListener(
+      'abort',
+      function abortSignalFetchErrorHandler() {
+        deferred$.reject(abortSignal.reason);
+      },
+      { once: true },
+    );
     response$
       .then(function fetchSuccessHandler(res) {
         deferred$.resolve(res);

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -115,7 +115,7 @@ export function normalizeNodeRequest(
     }
   }
   if (nodeResponse?.once) {
-    const controller = new AbortController();
+    const controller = new fetchAPI.AbortController();
     signal = controller.signal;
     registerAbortCtrl?.(controller);
 

--- a/packages/server/src/uwebsockets.ts
+++ b/packages/server/src/uwebsockets.ts
@@ -1,5 +1,5 @@
 import type { FetchAPI } from './types.js';
-import { isPromise, ServerAdapterRequestAbortSignal } from './utils.js';
+import { isPromise } from './utils.js';
 
 export interface UWSRequest {
   getMethod(): string;
@@ -31,10 +31,10 @@ interface GetRequestFromUWSOpts {
   req: UWSRequest;
   res: UWSResponse;
   fetchAPI: FetchAPI;
-  signal: AbortSignal;
+  ctrl: AbortController;
 }
 
-export function getRequestFromUWSRequest({ req, res, fetchAPI, signal }: GetRequestFromUWSOpts) {
+export function getRequestFromUWSRequest({ req, res, fetchAPI, ctrl }: GetRequestFromUWSOpts) {
   const method = req.getMethod();
 
   let duplex: 'half' | undefined;
@@ -70,7 +70,7 @@ export function getRequestFromUWSRequest({ req, res, fetchAPI, signal }: GetRequ
   let getReadableStream: (() => ReadableStream) | undefined;
   if (method !== 'get' && method !== 'head') {
     duplex = 'half';
-    signal.addEventListener('abort', () => {
+    ctrl.signal.addEventListener('abort', () => {
       stop();
     });
     let readableStream: ReadableStream;
@@ -124,7 +124,7 @@ export function getRequestFromUWSRequest({ req, res, fetchAPI, signal }: GetRequ
     get body() {
       return getBody();
     },
-    signal,
+    signal: ctrl.signal,
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore - not in the TS types yet
     duplex,
@@ -202,7 +202,7 @@ export function createWritableFromUWS(uwsResponse: UWSResponse, fetchAPI: FetchA
 export function sendResponseToUwsOpts(
   uwsResponse: UWSResponse,
   fetchResponse: Response,
-  signal: ServerAdapterRequestAbortSignal,
+  ctrl: AbortController,
   fetchAPI: FetchAPI,
 ) {
   if (!fetchResponse) {
@@ -211,7 +211,7 @@ export function sendResponseToUwsOpts(
     return;
   }
   const bufferOfRes: Uint8Array = (fetchResponse as any)._buffer;
-  if (signal.aborted) {
+  if (ctrl.signal.aborted) {
     return;
   }
   uwsResponse.cork(() => {
@@ -240,17 +240,17 @@ export function sendResponseToUwsOpts(
   if (bufferOfRes || !fetchResponse.body) {
     return;
   }
-  signal.addEventListener('abort', () => {
+  ctrl.signal.addEventListener('abort', () => {
     if (!fetchResponse.body?.locked) {
-      fetchResponse.body?.cancel(signal.reason);
+      fetchResponse.body?.cancel(ctrl.signal.reason);
     }
   });
   return fetchResponse.body
     .pipeTo(createWritableFromUWS(uwsResponse, fetchAPI), {
-      signal,
+      signal: ctrl.signal,
     })
     .catch(err => {
-      if (signal.aborted) {
+      if (ctrl.signal.aborted) {
         return;
       }
       throw err;

--- a/packages/server/src/uwebsockets.ts
+++ b/packages/server/src/uwebsockets.ts
@@ -70,9 +70,13 @@ export function getRequestFromUWSRequest({ req, res, fetchAPI, ctrl }: GetReques
   let getReadableStream: (() => ReadableStream) | undefined;
   if (method !== 'get' && method !== 'head') {
     duplex = 'half';
-    ctrl.signal.addEventListener('abort', () => {
-      stop();
-    });
+    ctrl.signal.addEventListener(
+      'abort',
+      () => {
+        stop();
+      },
+      { once: true },
+    );
     let readableStream: ReadableStream;
     getReadableStream = () => {
       if (!readableStream) {
@@ -240,11 +244,15 @@ export function sendResponseToUwsOpts(
   if (bufferOfRes || !fetchResponse.body) {
     return;
   }
-  ctrl.signal.addEventListener('abort', () => {
-    if (!fetchResponse.body?.locked) {
-      fetchResponse.body?.cancel(ctrl.signal.reason);
-    }
-  });
+  ctrl.signal.addEventListener(
+    'abort',
+    () => {
+      if (!fetchResponse.body?.locked) {
+        fetchResponse.body?.cancel(ctrl.signal.reason);
+      }
+    },
+    { once: true },
+  );
   return fetchResponse.body
     .pipeTo(createWritableFromUWS(uwsResponse, fetchAPI), {
       signal: ctrl.signal,

--- a/packages/server/test/abort.spec.ts
+++ b/packages/server/test/abort.spec.ts
@@ -16,7 +16,7 @@ describe('Request Abort', () => {
             ),
         );
         server.addOnceHandler(adapter);
-        const abortCtrl = new AbortController();
+        const abortCtrl = new fetchAPI.AbortController();
         fetchAPI.fetch(server.url, { signal: abortCtrl.signal }).then(
           () => {},
           () => {},

--- a/packages/server/test/adapter.fetch.spec.ts
+++ b/packages/server/test/adapter.fetch.spec.ts
@@ -3,7 +3,7 @@ import { runTestsForEachFetchImpl } from './test-fetch.js';
 
 describe('adapter.fetch', () => {
   runTestsForEachFetchImpl(
-    (_, { fetchAPI: { Request, Response, URL }, createServerAdapter }) => {
+    (_, { fetchAPI: { Request, Response, URL, AbortController }, createServerAdapter }) => {
       // Request as first parameter
       it('should accept Request as a first argument', async () => {
         const handleRequest = jest.fn();

--- a/packages/server/test/fastify.spec.ts
+++ b/packages/server/test/fastify.spec.ts
@@ -44,7 +44,13 @@ describe('Fastify', () => {
     return;
   }
   runTestsForEachFetchImpl(
-    (_, { fetchAPI: { ReadableStream, Response, TextEncoder, URL }, createServerAdapter }) => {
+    (
+      _,
+      {
+        fetchAPI: { ReadableStream, Response, TextEncoder, URL, AbortController },
+        createServerAdapter,
+      },
+    ) => {
       let serverAdapter: FastifyServerAdapter;
       const fastifyServer = fastify();
       fastifyServer.route({

--- a/packages/server/test/proxy.spec.ts
+++ b/packages/server/test/proxy.spec.ts
@@ -10,7 +10,7 @@ describe('Proxy', () => {
     return;
   }
   runTestsForEachFetchImpl(
-    (_, { createServerAdapter, fetchAPI: { fetch, Response, URL } }) => {
+    (_, { createServerAdapter, fetchAPI: { fetch, Response, URL, AbortSignal } }) => {
       let aborted: boolean = false;
       const originalAdapter = createServerAdapter(async request => {
         if (request.url.endsWith('/delay')) {


### PR DESCRIPTION
`AbortController` is heavy, and `AbortSignal.timeout` causes memory leaks.
So this ponyfill would reduce the overhead and remove the leaks.