### PR TITLE
fix(server): add `waitUntil` to the server context in Fastify integration

### DIFF
--- a/.changeset/blue-pugs-provide.md
+++ b/.changeset/blue-pugs-provide.md
@@ -1,0 +1,7 @@
+---
+'@whatwg-node/server': patch
+---
+
+While calling \`handleNodeRequest\` or \`handleNodeRequestAndResponse\`
+
+Fixes the issue with Fastify integration that uses the mentioned methods

--- a/.changeset/blue-pugs-provide.md
+++ b/.changeset/blue-pugs-provide.md
@@ -2,6 +2,7 @@
 '@whatwg-node/server': patch
 ---
 
-While calling \`handleNodeRequest\` or \`handleNodeRequestAndResponse\`
+While calling `handleNodeRequest` or `handleNodeRequestAndResponse`, `waitUntil` is not added automatically as in `requestListener` for Node.js integration.
+This change adds `waitUntil` into the `serverContext` if not present.
 
 Fixes the issue with Fastify integration that uses the mentioned methods


### PR DESCRIPTION
While calling `handleNodeRequest` or `handleNodeRequestAndResponse`, `waitUntil` is not added automatically as in `requestListener` for Node.js integration.
This change adds `waitUntil` into the `serverContext` if not present.

Fixes the issue with Fastify integration that uses the mentioned methods