### PR TITLE
Test if it leaks when the given signal never aborts and connection succeeds

### DIFF
--- a/.changeset/seven-forks-tease.md
+++ b/.changeset/seven-forks-tease.md
@@ -1,0 +1,11 @@
+---
+'@whatwg-node/node-fetch': patch
+---
+
+Remove the event listener on the provided `AbortSignal` when `node-libcurl` is used, the connection finishes to prevent
+potential memory leaks;
+
+```ts
+const res = await fetch(URL, { signal: new AbortController().signal });
+// AbortController is never aborted, and HTTP request is done as expected successfully
+```

--- a/packages/node-fetch/tests/fetch.spec.ts
+++ b/packages/node-fetch/tests/fetch.spec.ts
@@ -254,6 +254,14 @@ describe('Node Fetch Ponyfill', () => {
         expect(response.status).toBe(200);
         expect(response.url === 'https://github.com' || response.redirected).toBeTruthy();
       });
+      it('does not leak when signal is not used', async () => {
+        const res = await fetchPonyfill(baseUrl, { signal: new AbortController().signal });
+        await res.text();
+      });
+      it('does not leak when timeout signal is not used', async () => {
+        const res = await fetchPonyfill(baseUrl, { signal: AbortSignal.timeout(10_000) });
+        await res.text();
+      });
     },
   );
 });

--- a/packages/server/test/abort.spec.ts
+++ b/packages/server/test/abort.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { runTestsForEachFetchImpl } from './test-fetch';
 import { runTestsForEachServerImpl } from './test-server';
 

--- a/packages/server/test/abort.spec.ts
+++ b/packages/server/test/abort.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, it } from '@jest/globals';
 import { runTestsForEachFetchImpl } from './test-fetch';
 import { runTestsForEachServerImpl } from './test-server';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,7 +319,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-syntax-import-meta@7.10.4", "@babel/plugin-syntax-import-meta@^7.10.4":
+"@babel/plugin-syntax-import-meta@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz#ee601348c370fa334d2207be158777496521fd51"
   integrity sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==


### PR DESCRIPTION
This PR adds two tests;
- Adds an `AbortSignal` from an `AbortController` never aborts, and the fetch call succeeds to see if it leaks
- Adds an `AbortSignal.timeout` and it doesn't timeout and fetch call succeeds before it times out. And we check if it leaks

And it also removes the event listener added in `node-libcurl` based fetch implementation to make sure it doesn't leak.
This change doesn't affect Hive Gateway's this issue https://github.com/graphql-hive/gateway/issues/303#issuecomment-2575383178 because Hive GW doesn't use node-libcurl directly. Only tests are added to see if the leak is reproduced regardless the change.