### PR TITLE
enhance(node-fetch): make `ReadableStream[Symbol.asyncIterator]` `AsyncIterableIterator` rather than `AsyncIterator` only

### DIFF
--- a/.changeset/afraid-lies-nail.md
+++ b/.changeset/afraid-lies-nail.md
@@ -1,0 +1,7 @@
+---
+'@whatwg-node/node-fetch': patch
+'@whatwg-node/fetch': patch
+---
+
+`ReadableStream`'s `Symbol.asyncIterator` now returns `AsyncIterableIterator` like before even if it
+is ok to return `AsyncIterator` right now. It is safer to return `AsyncIterableIterator` because it is a common mistake to use `AsyncIterator` as `AsyncIterable`.

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -171,6 +171,9 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
   [Symbol.asyncIterator]() {
     const iterator = this.readable[Symbol.asyncIterator]();
     return {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
       next: () => iterator.next(),
       return: () => {
         if (!this.readable.destroyed) {


### PR DESCRIPTION
`ReadableStream`'s `Symbol.asyncIterator` now returns `AsyncIterableIterator` like before even if it
is ok to return `AsyncIterator`.
It is safer to return `AsyncIterableIterator` because it is a common mistake to use `AsyncIterator` as `AsyncIterable`.