### PR TITLE
feat(node-fetch): improve file access

### DIFF
--- a/.changeset/tough-moles-arrive.md
+++ b/.changeset/tough-moles-arrive.md
@@ -1,0 +1,7 @@
+---
+'@whatwg-node/node-fetch': patch
+---
+
+When `fetch('file:///...')` is used to read files;
+- 404 is returned if the file is missing
+- 403 is returned if the file is not accessible

--- a/packages/node-fetch/src/fetch.ts
+++ b/packages/node-fetch/src/fetch.ts
@@ -13,6 +13,7 @@ const BASE64_SUFFIX = ';base64';
 async function getResponseForFile(url: string) {
   const path = fileURLToPath(url);
   try {
+    await fsPromises.access(path, fsPromises.constants.R_OK);
     const stats = await fsPromises.stat(path, {
       bigint: true,
     });

--- a/packages/node-fetch/tests/non-http-fetch.spec.ts
+++ b/packages/node-fetch/tests/non-http-fetch.spec.ts
@@ -19,6 +19,10 @@ describe('File protocol', () => {
     );
     expect(response.status).toBe(404);
   });
+  it('returns 403 if file is not accessible', async () => {
+    const response = await fetchPonyfill(pathToFileURL('/etc/shadow'));
+    expect(response.status).toBe(403);
+  });
 });
 
 describe('data uris', () => {

--- a/packages/node-fetch/tests/non-http-fetch.spec.ts
+++ b/packages/node-fetch/tests/non-http-fetch.spec.ts
@@ -4,13 +4,21 @@ import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from '@jest/globals';
 import { fetchPonyfill } from '../src/fetch.js';
 
-it('should respect file protocol', async () => {
-  const response = await fetchPonyfill(
-    pathToFileURL(join(process.cwd(), './packages/node-fetch/tests/fixtures/test.json')),
-  );
-  expect(response.status).toBe(200);
-  const body = await response.json();
-  expect(body.foo).toBe('bar');
+describe('File protocol', () => {
+  it('reads', async () => {
+    const response = await fetchPonyfill(
+      pathToFileURL(join(process.cwd(), './packages/node-fetch/tests/fixtures/test.json')),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.foo).toBe('bar');
+  });
+  it('returns 404 if file does not exist', async () => {
+    const response = await fetchPonyfill(
+      pathToFileURL(join(process.cwd(), './packages/node-fetch/tests/fixtures/missing.json')),
+    );
+    expect(response.status).toBe(404);
+  });
 });
 
 describe('data uris', () => {

--- a/packages/node-fetch/tests/non-http-fetch.spec.ts
+++ b/packages/node-fetch/tests/non-http-fetch.spec.ts
@@ -1,6 +1,4 @@
 import { Buffer } from 'node:buffer';
-import { unlinkSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from '@jest/globals';
@@ -22,15 +20,8 @@ describe('File protocol', () => {
     expect(response.status).toBe(404);
   });
   it('returns 403 if file is not accessible', async () => {
-    const tmpDir = tmpdir();
-    const path = join(tmpDir, 'forbidden.json');
-    writeFileSync(path, '{ "test": 1 }', { mode: 0o000 });
-    try {
-      const response = await fetchPonyfill(pathToFileURL(path));
-      expect(response.status).toBe(403);
-    } finally {
-      unlinkSync(path);
-    }
+    const response = await fetchPonyfill(pathToFileURL('/root/private_data.txt'));
+    expect(response.status).toBe(403);
   });
 });
 


### PR DESCRIPTION
When `fetch('file:///...')` is used to read files;
- 404 is returned if the file is missing
- 403 is returned if the file is not accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for local file fetching: requests for missing files now return a 404 status, while those with restricted access return a 403 status.
- **Tests**
	- Introduced a new test suite for the file protocol, verifying successful file reads, handling of missing files, and access restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->