### PR TITLE
enhance(server): use native AbortController and AbortSignal

### DIFF
--- a/.changeset/metal-moles-care.md
+++ b/.changeset/metal-moles-care.md
@@ -1,5 +1,7 @@
 ---
-'@whatwg-node/server': patch
+'@whatwg-node/server': minor
+'@whatwg-node/node-fetch': patch
 ---
 
-Use native AbortSignal and AbortController for Request.signal
+- Use native AbortSignal and AbortController for Request.signal
+- Remove custom AbortSignal implementation (ServerAdapterAbortSignal)

--- a/.changeset/metal-moles-care.md
+++ b/.changeset/metal-moles-care.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/server': patch
+---
+
+Use native AbortSignal and AbortController for Request.signal

--- a/packages/node-fetch/src/Request.ts
+++ b/packages/node-fetch/src/Request.ts
@@ -73,7 +73,7 @@ export class PonyfillRequest<TJSON = any> extends PonyfillBody<TJSON> implements
     this.redirect = requestInit?.redirect || 'follow';
     this.referrer = requestInit?.referrer || 'about:client';
     this.referrerPolicy = requestInit?.referrerPolicy || 'no-referrer';
-    this._signal = requestInit?.signal;
+    this.signal = requestInit?.signal || new AbortController().signal;
     this.headersSerializer = requestInit?.headersSerializer;
     this.duplex = requestInit?.duplex || 'half';
 
@@ -137,16 +137,7 @@ export class PonyfillRequest<TJSON = any> extends PonyfillBody<TJSON> implements
 
   agent: HTTPAgent | HTTPSAgent | false | undefined;
 
-  private _signal: AbortSignal | undefined | null;
-
-  get signal() {
-    // Create a new signal only if needed
-    // Because the creation of signal is expensive
-    if (!this._signal) {
-      this._signal = new AbortController().signal;
-    }
-    return this._signal!;
-  }
+  signal: AbortSignal;
 
   clone(): PonyfillRequest<TJSON> {
     return this;

--- a/packages/node-fetch/src/fetchCurl.ts
+++ b/packages/node-fetch/src/fetchCurl.ts
@@ -30,11 +30,7 @@ export function fetchCurl<TResponseJSON = any, TRequestJSON = any>(
   curlHandle.enable(CurlFeature.StreamResponse);
 
   curlHandle.setStreamProgressCallback(function () {
-    return fetchRequest['_signal']?.aborted
-      ? process.env.DEBUG
-        ? CurlProgressFunc.Continue
-        : 1
-      : 0;
+    return fetchRequest.signal.aborted ? (process.env.DEBUG ? CurlProgressFunc.Continue : 1) : 0;
   });
 
   if (fetchRequest['bodyType'] === 'String') {
@@ -92,8 +88,8 @@ export function fetchCurl<TResponseJSON = any, TRequestJSON = any>(
       }
     }
   }
-  if (fetchRequest['_signal']) {
-    fetchRequest['_signal'].addEventListener('abort', onAbort, { once: true });
+  if (fetchRequest.signal) {
+    fetchRequest.signal.addEventListener('abort', onAbort, { once: true });
   }
   curlHandle.once('end', function endListener() {
     try {
@@ -101,8 +97,8 @@ export function fetchCurl<TResponseJSON = any, TRequestJSON = any>(
     } catch (e) {
       deferredPromise.reject(e);
     }
-    if (fetchRequest['_signal']) {
-      fetchRequest['_signal'].removeEventListener('abort', onAbort);
+    if (fetchRequest.signal) {
+      fetchRequest.signal.removeEventListener('abort', onAbort);
     }
   });
   curlHandle.once('error', function errorListener(error: any) {
@@ -127,7 +123,7 @@ export function fetchCurl<TResponseJSON = any, TRequestJSON = any>(
 
       pipeline(stream, outputStream, {
         end: true,
-        signal: fetchRequest['_signal'] ?? undefined,
+        signal: fetchRequest.signal,
       })
         .then(() => {
           if (!stream.destroyed) {

--- a/packages/node-fetch/src/fetchNodeHttp.ts
+++ b/packages/node-fetch/src/fetchNodeHttp.ts
@@ -47,14 +47,14 @@ export function fetchNodeHttp<TResponseJSON = any, TRequestJSON = any>(
         nodeRequest = requestFn(fetchRequest.parsedUrl, {
           method: fetchRequest.method,
           headers: nodeHeaders,
-          signal: fetchRequest['_signal'] ?? undefined,
+          signal: fetchRequest.signal,
           agent: fetchRequest.agent,
         });
       } else {
         nodeRequest = requestFn(fetchRequest.url, {
           method: fetchRequest.method,
           headers: nodeHeaders,
-          signal: fetchRequest['_signal'] ?? undefined,
+          signal: fetchRequest.signal,
           agent: fetchRequest.agent,
         });
       }
@@ -107,7 +107,7 @@ export function fetchNodeHttp<TResponseJSON = any, TRequestJSON = any>(
           }
         }
         pipeline(nodeResponse, outputStream, {
-          signal: fetchRequest['_signal'] ?? undefined,
+          signal: fetchRequest.signal,
           end: true,
         })
           .then(() => {

--- a/packages/server/src/createServerAdapter.ts
+++ b/packages/server/src/createServerAdapter.ts
@@ -330,7 +330,7 @@ function createServerAdapter<
       controller.abort();
     });
     res.onAborted = function (cb: () => void) {
-      controller.signal.addEventListener('abort', cb);
+      controller.signal.addEventListener('abort', cb, { once: true });
     };
     const request = getRequestFromUWSRequest({
       req,
@@ -411,7 +411,7 @@ function createServerAdapter<
       return handleRequestWithWaitUntil(request, ...maybeCtx);
     }
     const res$ = handleRequestWithWaitUntil(input, ...maybeCtx);
-    return handleAbortSignalAndPromiseResponse(res$, (input as any)._signal);
+    return handleAbortSignalAndPromiseResponse(res$, input.signal);
   };
 
   const genericRequestHandler = (

--- a/packages/server/src/createServerAdapter.ts
+++ b/packages/server/src/createServerAdapter.ts
@@ -32,7 +32,6 @@ import {
   NodeResponse,
   normalizeNodeRequest,
   sendNodeResponse,
-  ServerAdapterRequestAbortSignal,
 } from './utils.js';
 import {
   fakePromise,
@@ -319,7 +318,7 @@ function createServerAdapter<
         ? completeAssign(defaultServerContext, ...ctx)
         : defaultServerContext;
 
-    const signal = new ServerAdapterRequestAbortSignal();
+    const controller = new AbortController();
     const originalResEnd = res.end.bind(res);
     let resEnded = false;
     res.end = function (data: any) {
@@ -328,16 +327,16 @@ function createServerAdapter<
     };
     const originalOnAborted = res.onAborted.bind(res);
     originalOnAborted(function () {
-      signal.sendAbort();
+      controller.abort();
     });
     res.onAborted = function (cb: () => void) {
-      signal.addEventListener('abort', cb);
+      controller.signal.addEventListener('abort', cb);
     };
     const request = getRequestFromUWSRequest({
       req,
       res,
       fetchAPI,
-      signal,
+      controller,
     });
     let response$: Response | Promise<Response> | undefined;
     try {
@@ -349,8 +348,8 @@ function createServerAdapter<
       return response$
         .catch((e: any) => handleErrorFromRequestHandler(e, fetchAPI.Response))
         .then(response => {
-          if (!signal.aborted && !resEnded) {
-            return sendResponseToUwsOpts(res, response, signal, fetchAPI);
+          if (!controller.signal.aborted && !resEnded) {
+            return sendResponseToUwsOpts(res, response, controller, fetchAPI);
           }
         })
         .catch(err => {
@@ -360,8 +359,8 @@ function createServerAdapter<
         });
     }
     try {
-      if (!signal.aborted && !resEnded) {
-        return sendResponseToUwsOpts(res, response$, signal, fetchAPI);
+      if (!controller.signal.aborted && !resEnded) {
+        return sendResponseToUwsOpts(res, response$, controller, fetchAPI);
       }
     } catch (err: any) {
       console.error(

--- a/packages/server/src/createServerAdapter.ts
+++ b/packages/server/src/createServerAdapter.ts
@@ -405,7 +405,11 @@ function createServerAdapter<
       if (isRequestInit(initOrCtx)) {
         const request = new fetchAPI.Request(input, initOrCtx);
         const res$ = handleRequestWithWaitUntil(request, ...restOfCtx);
-        return handleAbortSignalAndPromiseResponse(res$, (initOrCtx as RequestInit)?.signal);
+        const signal = (initOrCtx as RequestInit).signal;
+        if (signal) {
+          return handleAbortSignalAndPromiseResponse(res$, signal);
+        }
+        return res$;
       }
       const request = new fetchAPI.Request(input);
       return handleRequestWithWaitUntil(request, ...maybeCtx);

--- a/packages/server/src/plugins/useContentEncoding.ts
+++ b/packages/server/src/plugins/useContentEncoding.ts
@@ -1,4 +1,10 @@
-import { decompressedResponseMap, getSupportedEncodings } from '../utils.js';
+import type { Readable } from 'node:stream';
+import {
+  decompressedResponseMap,
+  getSupportedEncodings,
+  isAsyncIterable,
+  isReadable,
+} from '../utils.js';
 import type { ServerAdapterPlugin } from './types.js';
 
 export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServerContext> {
@@ -53,8 +59,9 @@ export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServe
         encodingMap.set(request, acceptEncoding.split(','));
       }
     },
-    onResponse({ request, response, setResponse, fetchAPI }) {
-      if (response.body) {
+    onResponse({ request, response, setResponse, fetchAPI, serverContext }) {
+      // Hack for avoiding to create whatwg-node to create a readable stream until it's needed
+      if ((response as any)['bodyInit'] || response.body) {
         const encodings = encodingMap.get(request);
         if (encodings) {
           const supportedEncoding = encodings.find(encoding =>
@@ -64,12 +71,42 @@ export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServe
             const compressionStream = new fetchAPI.CompressionStream(
               supportedEncoding as CompressionFormat,
             );
+            // To calculate final content-length
+            const contentLength = response.headers.get('content-length');
+            if (contentLength) {
+              const bufOfRes = (response as any)._buffer;
+              if (bufOfRes) {
+                const writer = compressionStream.writable.getWriter();
+                const write$ = writer.write(bufOfRes);
+                serverContext.waitUntil?.(write$);
+                const close$ = writer.close();
+                serverContext.waitUntil?.(close$);
+                const uint8Arrays$ = isReadable((compressionStream.readable as any)['readable'])
+                  ? collectReadableValues((compressionStream.readable as any)['readable'])
+                  : isAsyncIterable(compressionStream.readable)
+                    ? collectAsyncIterableValues(compressionStream.readable)
+                    : collectReadableStreamValues(compressionStream.readable);
+                return uint8Arrays$.then(uint8Arrays => {
+                  const chunks = uint8Arrays.flatMap(uint8Array => [...uint8Array]);
+                  const uint8Array = new Uint8Array(chunks);
+                  const newHeaders = new fetchAPI.Headers(response.headers);
+                  newHeaders.set('content-encoding', supportedEncoding);
+                  newHeaders.set('content-length', uint8Array.byteLength.toString());
+                  const compressedResponse = new fetchAPI.Response(uint8Array, {
+                    ...response,
+                    headers: newHeaders,
+                  });
+                  decompressedResponseMap.set(compressedResponse, response);
+                  setResponse(compressedResponse);
+                  const close$ = compressionStream.writable.close();
+                  serverContext.waitUntil?.(close$);
+                });
+              }
+            }
             const newHeaders = new fetchAPI.Headers(response.headers);
             newHeaders.set('content-encoding', supportedEncoding);
             newHeaders.delete('content-length');
-            const compressedBody = response.body!.pipeThrough(compressionStream, {
-              signal: request.signal,
-            });
+            const compressedBody = response.body!.pipeThrough(compressionStream);
             const compressedResponse = new fetchAPI.Response(compressedBody, {
               status: response.status,
               statusText: response.statusText,
@@ -82,4 +119,36 @@ export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServe
       }
     },
   };
+}
+
+function collectReadableValues<T>(readable: Readable): Promise<T[]> {
+  const values: T[] = [];
+  readable.on('data', value => values.push(value));
+  return new Promise((resolve, reject) => {
+    readable.once('end', () => resolve(values));
+    readable.once('error', reject);
+  });
+}
+
+async function collectAsyncIterableValues<T>(asyncIterable: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const value of asyncIterable) {
+    values.push(value);
+  }
+  return values;
+}
+
+async function collectReadableStreamValues<T>(readableStream: ReadableStream<T>): Promise<T[]> {
+  const reader = readableStream.getReader();
+  const values: T[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      reader.releaseLock();
+      break;
+    } else if (value) {
+      values.push(value);
+    }
+  }
+  return values;
 }

--- a/packages/server/src/plugins/useContentEncoding.ts
+++ b/packages/server/src/plugins/useContentEncoding.ts
@@ -1,10 +1,4 @@
-import type { Readable } from 'node:stream';
-import {
-  decompressedResponseMap,
-  getSupportedEncodings,
-  isAsyncIterable,
-  isReadable,
-} from '../utils.js';
+import { decompressedResponseMap, getSupportedEncodings } from '../utils.js';
 import type { ServerAdapterPlugin } from './types.js';
 
 export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServerContext> {
@@ -59,9 +53,8 @@ export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServe
         encodingMap.set(request, acceptEncoding.split(','));
       }
     },
-    onResponse({ request, response, setResponse, fetchAPI, serverContext }) {
-      // Hack for avoiding to create whatwg-node to create a readable stream until it's needed
-      if ((response as any)['bodyInit'] || response.body) {
+    onResponse({ request, response, setResponse, fetchAPI }) {
+      if (response.body) {
         const encodings = encodingMap.get(request);
         if (encodings) {
           const supportedEncoding = encodings.find(encoding =>
@@ -71,42 +64,12 @@ export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServe
             const compressionStream = new fetchAPI.CompressionStream(
               supportedEncoding as CompressionFormat,
             );
-            // To calculate final content-length
-            const contentLength = response.headers.get('content-length');
-            if (contentLength) {
-              const bufOfRes = (response as any)._buffer;
-              if (bufOfRes) {
-                const writer = compressionStream.writable.getWriter();
-                const write$ = writer.write(bufOfRes);
-                serverContext.waitUntil?.(write$);
-                const close$ = writer.close();
-                serverContext.waitUntil?.(close$);
-                const uint8Arrays$ = isReadable((compressionStream.readable as any)['readable'])
-                  ? collectReadableValues((compressionStream.readable as any)['readable'])
-                  : isAsyncIterable(compressionStream.readable)
-                    ? collectAsyncIterableValues(compressionStream.readable)
-                    : collectReadableStreamValues(compressionStream.readable);
-                return uint8Arrays$.then(uint8Arrays => {
-                  const chunks = uint8Arrays.flatMap(uint8Array => [...uint8Array]);
-                  const uint8Array = new Uint8Array(chunks);
-                  const newHeaders = new fetchAPI.Headers(response.headers);
-                  newHeaders.set('content-encoding', supportedEncoding);
-                  newHeaders.set('content-length', uint8Array.byteLength.toString());
-                  const compressedResponse = new fetchAPI.Response(uint8Array, {
-                    ...response,
-                    headers: newHeaders,
-                  });
-                  decompressedResponseMap.set(compressedResponse, response);
-                  setResponse(compressedResponse);
-                  const close$ = compressionStream.writable.close();
-                  serverContext.waitUntil?.(close$);
-                });
-              }
-            }
             const newHeaders = new fetchAPI.Headers(response.headers);
             newHeaders.set('content-encoding', supportedEncoding);
             newHeaders.delete('content-length');
-            const compressedBody = response.body!.pipeThrough(compressionStream);
+            const compressedBody = response.body!.pipeThrough(compressionStream, {
+              signal: request.signal,
+            });
             const compressedResponse = new fetchAPI.Response(compressedBody, {
               status: response.status,
               statusText: response.statusText,
@@ -119,36 +82,4 @@ export function useContentEncoding<TServerContext>(): ServerAdapterPlugin<TServe
       }
     },
   };
-}
-
-function collectReadableValues<T>(readable: Readable): Promise<T[]> {
-  const values: T[] = [];
-  readable.on('data', value => values.push(value));
-  return new Promise((resolve, reject) => {
-    readable.once('end', () => resolve(values));
-    readable.once('error', reject);
-  });
-}
-
-async function collectAsyncIterableValues<T>(asyncIterable: AsyncIterable<T>): Promise<T[]> {
-  const values: T[] = [];
-  for await (const value of asyncIterable) {
-    values.push(value);
-  }
-  return values;
-}
-
-async function collectReadableStreamValues<T>(readableStream: ReadableStream<T>): Promise<T[]> {
-  const reader = readableStream.getReader();
-  const values: T[] = [];
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      reader.releaseLock();
-      break;
-    } else if (value) {
-      values.push(value);
-    }
-  }
-  return values;
 }

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -82,50 +82,11 @@ function isRequestBody(body: any): body is BodyInit {
   return false;
 }
 
-export class ServerAdapterRequestAbortSignal extends EventTarget implements AbortSignal {
-  aborted = false;
-  private _onabort: ((this: AbortSignal, ev: Event) => any) | null = null;
-  reason: any;
-
-  throwIfAborted(): void {
-    if (this.aborted) {
-      throw this.reason;
-    }
-  }
-
-  sendAbort() {
-    this.reason = new DOMException('This operation was aborted', 'AbortError');
-    this.aborted = true;
-    this.dispatchEvent(new Event('abort'));
-  }
-
-  get onabort() {
-    return this._onabort;
-  }
-
-  set onabort(value) {
-    this._onabort = value;
-    if (value) {
-      this.addEventListener('abort', value);
-    } else {
-      this.removeEventListener('abort', value);
-    }
-  }
-
-  any(signals: Iterable<AbortSignal>): AbortSignal {
-    return AbortSignal.any([...signals]);
-  }
-}
-
 let bunNodeCompatModeWarned = false;
 
 export const nodeRequestResponseMap = new WeakMap<NodeRequest, NodeResponse>();
 
-export function normalizeNodeRequest(
-  nodeRequest: NodeRequest,
-  fetchAPI: FetchAPI,
-  registerSignal?: (signal: ServerAdapterRequestAbortSignal) => void,
-): Request {
+export function normalizeNodeRequest(nodeRequest: NodeRequest, fetchAPI: FetchAPI): Request {
   const rawRequest = nodeRequest.raw || nodeRequest.req || nodeRequest;
   let fullUrl = buildFullUrl(rawRequest);
   if (nodeRequest.query) {
@@ -135,8 +96,6 @@ export function normalizeNodeRequest(
     }
     fullUrl = url.toString();
   }
-
-  let signal: AbortSignal | undefined;
 
   const nodeResponse = nodeRequestResponseMap.get(nodeRequest);
   nodeRequestResponseMap.delete(nodeRequest);
@@ -149,25 +108,12 @@ export function normalizeNodeRequest(
       }
     }
   }
+  const controller = new AbortController();
   if (nodeResponse?.once) {
-    let sendAbortSignal: VoidFunction;
-
-    // If ponyfilled
-    if (fetchAPI.Request !== globalThis.Request) {
-      const newSignal = new ServerAdapterRequestAbortSignal();
-      registerSignal?.(newSignal);
-      signal = newSignal;
-      sendAbortSignal = () => (signal as ServerAdapterRequestAbortSignal).sendAbort();
-    } else {
-      const controller = new AbortController();
-      signal = controller.signal;
-      sendAbortSignal = () => controller.abort();
-    }
-
     const closeEventListener: EventListener = () => {
-      if (signal && !signal.aborted) {
+      if (!controller.signal.aborted) {
         Object.defineProperty(rawRequest, 'aborted', { value: true });
-        sendAbortSignal();
+        controller.abort();
       }
     };
 
@@ -183,7 +129,7 @@ export function normalizeNodeRequest(
     return new fetchAPI.Request(fullUrl, {
       method: nodeRequest.method,
       headers: normalizedHeaders,
-      signal: signal || null,
+      signal: controller.signal,
     });
   }
 
@@ -200,13 +146,13 @@ export function normalizeNodeRequest(
         method: nodeRequest.method || 'GET',
         headers: normalizedHeaders,
         body: maybeParsedBody,
-        signal: signal || null,
+        signal: controller.signal,
       });
     }
     const request = new fetchAPI.Request(fullUrl, {
       method: nodeRequest.method || 'GET',
       headers: normalizedHeaders,
-      signal: signal || null,
+      signal: controller.signal,
     });
     if (!request.headers.get('content-type')?.includes('json')) {
       request.headers.set('content-type', 'application/json; charset=utf-8');
@@ -254,7 +200,7 @@ It will affect your performance. Please check our Bun integration recipe, and av
           rawRequest.destroy(e);
         },
       }),
-      signal,
+      signal: controller.signal,
     } as RequestInit);
   }
 
@@ -262,10 +208,11 @@ It will affect your performance. Please check our Bun integration recipe, and av
   return new fetchAPI.Request(fullUrl, {
     method: nodeRequest.method,
     headers: normalizedHeaders,
-    body: rawRequest as any,
+    signal: controller.signal,
+    // @ts-expect-error - AsyncIterable is supported as body
+    body: rawRequest,
     duplex: 'half',
-    signal,
-  } as RequestInit);
+  });
 }
 
 export function isReadable(stream: any): stream is Readable {

--- a/packages/server/src/uwebsockets.ts
+++ b/packages/server/src/uwebsockets.ts
@@ -1,5 +1,5 @@
 import type { FetchAPI } from './types.js';
-import { isPromise, ServerAdapterRequestAbortSignal } from './utils.js';
+import { isPromise } from './utils.js';
 
 export interface UWSRequest {
   getMethod(): string;
@@ -31,10 +31,15 @@ interface GetRequestFromUWSOpts {
   req: UWSRequest;
   res: UWSResponse;
   fetchAPI: FetchAPI;
-  signal: AbortSignal;
+  controller: AbortController;
 }
 
-export function getRequestFromUWSRequest({ req, res, fetchAPI, signal }: GetRequestFromUWSOpts) {
+export function getRequestFromUWSRequest({
+  req,
+  res,
+  fetchAPI,
+  controller,
+}: GetRequestFromUWSOpts) {
   const method = req.getMethod();
 
   let duplex: 'half' | undefined;
@@ -70,7 +75,7 @@ export function getRequestFromUWSRequest({ req, res, fetchAPI, signal }: GetRequ
   let getReadableStream: (() => ReadableStream) | undefined;
   if (method !== 'get' && method !== 'head') {
     duplex = 'half';
-    signal.addEventListener('abort', () => {
+    controller.signal.addEventListener('abort', () => {
       stop();
     });
     let readableStream: ReadableStream;
@@ -124,7 +129,7 @@ export function getRequestFromUWSRequest({ req, res, fetchAPI, signal }: GetRequ
     get body() {
       return getBody();
     },
-    signal,
+    signal: controller.signal,
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore - not in the TS types yet
     duplex,
@@ -202,7 +207,7 @@ export function createWritableFromUWS(uwsResponse: UWSResponse, fetchAPI: FetchA
 export function sendResponseToUwsOpts(
   uwsResponse: UWSResponse,
   fetchResponse: Response,
-  signal: ServerAdapterRequestAbortSignal,
+  controller: AbortController,
   fetchAPI: FetchAPI,
 ) {
   if (!fetchResponse) {
@@ -211,7 +216,7 @@ export function sendResponseToUwsOpts(
     return;
   }
   const bufferOfRes: Uint8Array = (fetchResponse as any)._buffer;
-  if (signal.aborted) {
+  if (controller.signal.aborted) {
     return;
   }
   uwsResponse.cork(() => {
@@ -240,17 +245,17 @@ export function sendResponseToUwsOpts(
   if (bufferOfRes || !fetchResponse.body) {
     return;
   }
-  signal.addEventListener('abort', () => {
+  controller.signal.addEventListener('abort', () => {
     if (!fetchResponse.body?.locked) {
-      fetchResponse.body?.cancel(signal.reason);
+      fetchResponse.body?.cancel(controller.signal.reason);
     }
   });
   return fetchResponse.body
     .pipeTo(createWritableFromUWS(uwsResponse, fetchAPI), {
-      signal,
+      signal: controller.signal,
     })
     .catch(err => {
-      if (signal.aborted) {
+      if (controller.signal.aborted) {
         return;
       }
       throw err;

--- a/packages/server/src/uwebsockets.ts
+++ b/packages/server/src/uwebsockets.ts
@@ -75,9 +75,13 @@ export function getRequestFromUWSRequest({
   let getReadableStream: (() => ReadableStream) | undefined;
   if (method !== 'get' && method !== 'head') {
     duplex = 'half';
-    controller.signal.addEventListener('abort', () => {
-      stop();
-    });
+    controller.signal.addEventListener(
+      'abort',
+      () => {
+        stop();
+      },
+      { once: true },
+    );
     let readableStream: ReadableStream;
     getReadableStream = () => {
       if (!readableStream) {
@@ -245,11 +249,15 @@ export function sendResponseToUwsOpts(
   if (bufferOfRes || !fetchResponse.body) {
     return;
   }
-  controller.signal.addEventListener('abort', () => {
-    if (!fetchResponse.body?.locked) {
-      fetchResponse.body?.cancel(controller.signal.reason);
-    }
-  });
+  controller.signal.addEventListener(
+    'abort',
+    () => {
+      if (!fetchResponse.body?.locked) {
+        fetchResponse.body?.cancel(controller.signal.reason);
+      }
+    },
+    { once: true },
+  );
   return fetchResponse.body
     .pipeTo(createWritableFromUWS(uwsResponse, fetchAPI), {
       signal: controller.signal,


### PR DESCRIPTION
Apparently in the benchmarks, no need to use a custom implementation for AbortSignal in the server-side `Request.signal`.
Also we don't need to introduce signals lazily as they are not expensive anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated core dependencies for improved stability and performance.

- **Refactor**
  - Streamlined request and stream cancellation handling by adopting a standardized native approach, ensuring more consistent and reliable behavior.
  - Simplified abort signal management across various components, enhancing clarity and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->