### PR TITLE
fix(server): subsequent `onResponse` hooks get the latest `response`

### DIFF
--- a/.changeset/strange-peas-obey.md
+++ b/.changeset/strange-peas-obey.md
@@ -2,8 +2,7 @@
 '@whatwg-node/server': patch
 ---
 
-When two plugins uses `onResponse` hook and first one modifies the response, the second one should
-get the modified one;
+When two plugins use the `onResponse` hook and the first one modifies the response, the second one should get the modified one;
 
 ```ts
 [

--- a/.changeset/strange-peas-obey.md
+++ b/.changeset/strange-peas-obey.md
@@ -1,0 +1,25 @@
+---
+'@whatwg-node/server': patch
+---
+
+When two plugins uses `onResponse` hook and first one modifies the response, the second one should
+get the modified one;
+
+```ts
+[
+    {
+        onResponse({ setResponse, fetchAPI }) {
+            setResponse(
+                fetchAPI.Response.json({
+                    foo: 'bar'
+                }, { status: 418 })
+            )
+        }
+    },
+    {
+        onResponse({ response }) {
+            console.log(response.status) // 418
+        }
+    }
+]
+```

--- a/packages/server/src/createServerAdapter.ts
+++ b/packages/server/src/createServerAdapter.ts
@@ -1,11 +1,6 @@
 import { AsyncDisposableStack, DisposableSymbols } from '@whatwg-node/disposablestack';
 import * as DefaultFetchAPI from '@whatwg-node/fetch';
-import {
-  OnRequestHook,
-  OnResponseEventPayload,
-  OnResponseHook,
-  ServerAdapterPlugin,
-} from './plugins/types.js';
+import { OnRequestHook, OnResponseHook, ServerAdapterPlugin } from './plugins/types.js';
 import {
   FetchAPI,
   FetchEvent,
@@ -212,19 +207,16 @@ function createServerAdapter<
             if (onResponseHooks.length === 0) {
               return response;
             }
-            const onResponseHookPayload: OnResponseEventPayload<
-              TServerContext & ServerAdapterInitialContext
-            > = {
-              request,
-              response,
-              serverContext,
-              setResponse(newResponse) {
-                response = newResponse;
-              },
-              fetchAPI,
-            };
             const onResponseHooksIteration$ = iterateAsyncVoid(onResponseHooks, onResponseHook =>
-              onResponseHook(onResponseHookPayload),
+              onResponseHook({
+                request,
+                response,
+                serverContext,
+                setResponse(newResponse) {
+                  response = newResponse;
+                },
+                fetchAPI,
+              }),
             );
             if (isPromise(onResponseHooksIteration$)) {
               return onResponseHooksIteration$.then(() => response);

--- a/packages/server/test/plugins.spec.ts
+++ b/packages/server/test/plugins.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { Request, Response } from '@whatwg-node/fetch';
+import { createServerAdapter, OnResponseEventPayload } from '@whatwg-node/server';
+
+describe('Plugins', () => {
+  it('should reflect updated response in subsequent plugins', async () => {
+    const firstOnResponse = jest.fn((payload: OnResponseEventPayload<{}>) => {
+      payload.setResponse(Response.json({ message: 'Good bye!' }, { status: 418 }));
+    });
+    const secondOnResponse = jest.fn((_payload: OnResponseEventPayload<{}>) => {});
+    const adapter = createServerAdapter<{}>(() => Response.json({ message: 'Hello, World!' }), {
+      plugins: [{ onResponse: firstOnResponse }, { onResponse: secondOnResponse }],
+    });
+    const request = new Request('http://localhost');
+    const response = await adapter.fetch(request);
+    expect(response.status).toBe(418);
+    expect(await response.json()).toEqual({ message: 'Good bye!' });
+    expect(firstOnResponse.mock.calls[0][0].response.status).toBe(200);
+    expect(secondOnResponse.mock.calls[0][0].response.status).toBe(418);
+  });
+});

--- a/packages/server/test/plugins.spec.ts
+++ b/packages/server/test/plugins.spec.ts
@@ -1,21 +1,31 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { Request, Response } from '@whatwg-node/fetch';
-import { createServerAdapter, OnResponseEventPayload } from '@whatwg-node/server';
+import { createServerAdapter } from '@whatwg-node/server';
 
 describe('Plugins', () => {
   it('should reflect updated response in subsequent plugins', async () => {
-    const firstOnResponse = jest.fn((payload: OnResponseEventPayload<{}>) => {
-      payload.setResponse(Response.json({ message: 'Good bye!' }, { status: 418 }));
-    });
-    const secondOnResponse = jest.fn((_payload: OnResponseEventPayload<{}>) => {});
+    let firstRes: Response | undefined;
+    let secondRes: Response | undefined;
     const adapter = createServerAdapter<{}>(() => Response.json({ message: 'Hello, World!' }), {
-      plugins: [{ onResponse: firstOnResponse }, { onResponse: secondOnResponse }],
+      plugins: [
+        {
+          onResponse({ response, setResponse }) {
+            firstRes = response;
+            setResponse(Response.json({ message: 'Good bye!' }, { status: 418 }));
+          },
+        },
+        {
+          onResponse({ response }) {
+            secondRes = response;
+          },
+        },
+      ],
     });
     const request = new Request('http://localhost');
     const response = await adapter.fetch(request);
     expect(response.status).toBe(418);
     expect(await response.json()).toEqual({ message: 'Good bye!' });
-    expect(firstOnResponse.mock.calls[0][0].response.status).toBe(200);
-    expect(secondOnResponse.mock.calls[0][0].response.status).toBe(418);
+    expect(firstRes?.status).toBe(200);
+    expect(secondRes?.status).toBe(418);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/ardatan/whatwg-node/issues/2053

When two plugins use the `onResponse` hook and the first one modifies the response, the second one should
get the modified one;

```ts
[
    {
        onResponse({ setResponse, fetchAPI }) {
            setResponse(
                fetchAPI.Response.json({
                    foo: 'bar'
                }, { status: 418 })
            )
        }
    },
    {
        onResponse({ response }) {
            console.log(response.status) // 418
        }
    }
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the response propagation so that modifications by one plugin are visible to subsequent plugins.

- **Refactor**
  - Streamlined how plugin responses are handled for improved clarity and efficiency.

- **Tests**
  - Introduced tests to verify that updated responses are correctly passed through the plugin chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->