### PR TITLE
feat(server): New Instruments API

### DIFF
--- a/.changeset/@whatwg-node_server-2068-dependencies.md
+++ b/.changeset/@whatwg-node_server-2068-dependencies.md
@@ -3,4 +3,4 @@
 ---
 dependencies updates:
   - Updated dependency [`@whatwg-node/promise-helpers@^1.2.2` ↗︎](https://www.npmjs.com/package/@whatwg-node/promise-helpers/v/1.2.2) (from `^1.0.0`, in `dependencies`)
-  - Added dependency [`@envelop/instruments@1.0.0-alpha-20250227122402-42e2fa806ec3b7c2936e612924b153a20c8662c3` ↗︎](https://www.npmjs.com/package/@envelop/instruments/v/1.0.0) (to `dependencies`)
+  - Added dependency [`@envelop/instruments@1.0.0` ↗︎](https://www.npmjs.com/package/@envelop/instruments/v/1.0.0) (to `dependencies`)

--- a/.changeset/@whatwg-node_server-2068-dependencies.md
+++ b/.changeset/@whatwg-node_server-2068-dependencies.md
@@ -2,4 +2,5 @@
 "@whatwg-node/server": patch
 ---
 dependencies updates:
+  - Updated dependency [`@whatwg-node/promise-helpers@^1.2.2` ↗︎](https://www.npmjs.com/package/@whatwg-node/promise-helpers/v/1.2.2) (from `^1.0.0`, in `dependencies`)
   - Added dependency [`@envelop/instruments@1.0.0-alpha-20250227122402-42e2fa806ec3b7c2936e612924b153a20c8662c3` ↗︎](https://www.npmjs.com/package/@envelop/instruments/v/1.0.0) (to `dependencies`)

--- a/.changeset/@whatwg-node_server-2068-dependencies.md
+++ b/.changeset/@whatwg-node_server-2068-dependencies.md
@@ -2,4 +2,4 @@
 "@whatwg-node/server": patch
 ---
 dependencies updates:
-  - Added dependency [`@envelop/instruments@1.0.0-alpha-20250227114734-64d7083775b6c1ee4ce365437ae5f77c33aee3a5` ↗︎](https://www.npmjs.com/package/@envelop/instruments/v/1.0.0) (to `dependencies`)
+  - Added dependency [`@envelop/instruments@1.0.0-alpha-20250227122402-42e2fa806ec3b7c2936e612924b153a20c8662c3` ↗︎](https://www.npmjs.com/package/@envelop/instruments/v/1.0.0) (to `dependencies`)

--- a/.changeset/@whatwg-node_server-2068-dependencies.md
+++ b/.changeset/@whatwg-node_server-2068-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@whatwg-node/server": patch
+---
+dependencies updates:
+  - Added dependency [`@envelop/instruments@^5.0.3` ↗︎](https://www.npmjs.com/package/@envelop/instruments/v/5.0.3) (to `dependencies`)

--- a/.changeset/@whatwg-node_server-2068-dependencies.md
+++ b/.changeset/@whatwg-node_server-2068-dependencies.md
@@ -2,4 +2,4 @@
 "@whatwg-node/server": patch
 ---
 dependencies updates:
-  - Added dependency [`@envelop/instruments@^5.0.3` ↗︎](https://www.npmjs.com/package/@envelop/instruments/v/5.0.3) (to `dependencies`)
+  - Added dependency [`@envelop/instruments@1.0.0-alpha-20250227114734-64d7083775b6c1ee4ce365437ae5f77c33aee3a5` ↗︎](https://www.npmjs.com/package/@envelop/instruments/v/1.0.0) (to `dependencies`)

--- a/.changeset/purple-buses-try.md
+++ b/.changeset/purple-buses-try.md
@@ -2,4 +2,94 @@
 '@whatwg-node/server': minor
 ---
 
-Add new Tracer API
+Add new Instruments API
+
+Introducation of a new API allowing to instrument the graphql pipeline.
+
+This new API differs from already existing Hooks by not having access to intup/output of phases. The
+goal of `Instruments` is to run allow running code before, after or araound the **whole process of a
+phase**, incuding plugins hooks executions.
+
+The main use case of this new API is observability (monitoring, tracing, etc...).
+
+### Basic usage
+
+```ts
+import Sentry from '@sentry/node'
+import { createServerAdapter } from '@wahtwg-node/server'
+
+const server = createServerAdapter(
+  (req, res) => {
+    //...
+  },
+  {
+    plugins: [
+      {
+        instruments: {
+          request: ({ request }, wrapped) =>
+            Sentry.startSpan({ name: 'Graphql Operation' }, async () => {
+              try {
+                await wrapped()
+              } catch (err) {
+                Sentry.captureException(err)
+              }
+            })
+        }
+      }
+    ]
+  }
+)
+```
+
+### Mutliple instruments plugins
+
+It is possilbe to have multiple instruments plugins (Prometheus and Sentry for example), they will
+be automatically composed by envelop in the same order than the plugin array (first is outtermost,
+last is inner most).
+
+```ts
+import { createServerAdapter } from '@wahtwg-node/server'
+
+const getEnveloped = createServerAdapter(
+  (req, res) => {
+    //...
+  },
+  { plugins: [useSentry(), useOpentelemetry()] }
+)
+```
+
+```mermaid
+sequenceDiagram
+  Sentry->>Opentelemetry: ;
+  Opentelemetry->>Server Adapter: ;
+  Server Adapter->>Opentelemetry: ;
+  Opentelemetry->>Sentry: ;
+```
+
+### Custom instruments ordering
+
+If the default composition ordering doesn't suite your need, you can mannually compose instruments.
+This allows to have a different execution order of hooks and instruments.
+
+```ts
+import { composeInstruments, createServerAdapter } from '@wahtwg-node/server'
+
+const { instruments: sentryInstruments, ...sentryPlugin } = useSentry()
+const { instruments: otelInstruments, ...otelPlugin } = useOpentelemetry()
+const instruments = composeInstruments([otelInstruments, sentryInstruments])
+
+const getEnveloped = createServerAdapter(
+  (req, res) => {
+    //...
+  },
+  { plugins: [{ instruments }, sentryPlugin, otelPlugin] }
+)
+```
+
+```mermaid
+sequenceDiagram
+  Opentelemetry->>Sentry: ;
+  Sentry->>Server Adapter: ;
+  Server Adapter->>Sentry: ;
+  Sentry->>Opentelemetry: ;
+```

--- a/.changeset/purple-buses-try.md
+++ b/.changeset/purple-buses-try.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/server': minor
+---
+
+Add new Tracer API

--- a/.changeset/purple-buses-try.md
+++ b/.changeset/purple-buses-try.md
@@ -4,11 +4,11 @@
 
 Add new Instruments API
 
-Introducation of a new API allowing to instrument the graphql pipeline.
+Introduction of a new API allowing to instrument the graphql pipeline.
 
-This new API differs from already existing Hooks by not having access to intup/output of phases. The
-goal of `Instruments` is to run allow running code before, after or araound the **whole process of a
-phase**, incuding plugins hooks executions.
+This new API differs from already existing Hooks by not having access to input/output of phases. The
+goal of `Instruments` is to run allow running code before, after or around the **whole process of a
+phase**, including plugins hooks executions.
 
 The main use case of this new API is observability (monitoring, tracing, etc...).
 
@@ -16,7 +16,7 @@ The main use case of this new API is observability (monitoring, tracing, etc...)
 
 ```ts
 import Sentry from '@sentry/node'
-import { createServerAdapter } from '@wahtwg-node/server'
+import { createServerAdapter } from '@whatwg-node/server'
 
 const server = createServerAdapter(
   (req, res) => {
@@ -41,14 +41,14 @@ const server = createServerAdapter(
 )
 ```
 
-### Mutliple instruments plugins
+### Multiple instruments plugins
 
-It is possilbe to have multiple instruments plugins (Prometheus and Sentry for example), they will
-be automatically composed by envelop in the same order than the plugin array (first is outtermost,
+It is possible to have multiple instruments plugins (Prometheus and Sentry for example), they will
+be automatically composed by envelop in the same order than the plugin array (first is outermost,
 last is inner most).
 
 ```ts
-import { createServerAdapter } from '@wahtwg-node/server'
+import { createServerAdapter } from '@whatwg-node/server'
 
 const getEnveloped = createServerAdapter(
   (req, res) => {
@@ -68,11 +68,11 @@ sequenceDiagram
 
 ### Custom instruments ordering
 
-If the default composition ordering doesn't suite your need, you can mannually compose instruments.
+If the default composition ordering doesn't suite your need, you can manually compose instruments.
 This allows to have a different execution order of hooks and instruments.
 
 ```ts
-import { composeInstruments, createServerAdapter } from '@wahtwg-node/server'
+import { composeInstruments, createServerAdapter } from '@whatwg-node/server'
 
 const { instruments: sentryInstruments, ...sentryPlugin } = useSentry()
 const { instruments: otelInstruments, ...otelPlugin } = useOpentelemetry()

--- a/.changeset/purple-buses-try.md
+++ b/.changeset/purple-buses-try.md
@@ -50,7 +50,7 @@ last is inner most).
 ```ts
 import { createServerAdapter } from '@whatwg-node/server'
 
-const getEnveloped = createServerAdapter(
+const server = createServerAdapter(
   (req, res) => {
     //...
   },
@@ -78,7 +78,7 @@ const { instruments: sentryInstruments, ...sentryPlugin } = useSentry()
 const { instruments: otelInstruments, ...otelPlugin } = useOpentelemetry()
 const instruments = composeInstruments([otelInstruments, sentryInstruments])
 
-const getEnveloped = createServerAdapter(
+const server = createServerAdapter(
   (req, res) => {
     //...
   },

--- a/.changeset/tasty-berries-film.md
+++ b/.changeset/tasty-berries-film.md
@@ -1,5 +1,5 @@
 ---
-'@whatwg-node/promise-helpers': minor
+'@whatwg-node/promise-helpers': patch
 ---
 
 Fix return type of the callback of `iterateAsync`. The callback can actually return `null` or

--- a/.changeset/tasty-berries-film.md
+++ b/.changeset/tasty-berries-film.md
@@ -1,0 +1,6 @@
+---
+'@whatwg-node/promise-helpers': minor
+---
+
+Fix return type of the callback of `iterateAsync`. The callback can actually return `null` or
+`undefined`, the implementation is already handling this case.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,8 @@ jobs:
         uses: the-guild-org/shared-config/setup@main
         with:
           nodeVersion: 22
+      - name: Build
+        run: yarn build
       - name: Test
         uses: nick-fields/retry@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,8 +134,6 @@ jobs:
         uses: the-guild-org/shared-config/setup@main
         with:
           nodeVersion: 22
-      - name: Build
-        run: yarn build
       - name: Test
         uses: nick-fields/retry@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ package-lock.json
 eslint_report.json
 
 deno.lock
+.helix/config.toml
+.helix/languages.toml
+.mise.toml

--- a/deno.json
+++ b/deno.json
@@ -1,14 +1,6 @@
 {
   "imports": {
     "@jest/globals": "./deno-jest.ts",
-    "@whatwg-node/cookie-store": "./packages/cookie-store/src/index.ts",
-    "@whatwg-node/disposablestack": "./packages/disposablestack/src/index.ts",
-    "@whatwg-node/fetch": "./packages/fetch/dist/esm-ponyfill.js",
-    "@whatwg-node/events": "./packages/events/src/index.ts",
-    "fetchache": "./packages/fetchache/src/index.ts",
-    "@whatwg-node/node-fetch": "./packages/node-fetch/src/index.ts",
-    "@whatwg-node/server": "./packages/server/src/index.ts",
-    "@whatwg-node/server-plugin-cookies": "./packages/server-plugin-cookies/src/index.ts",
-    "@whatwg-node/promise-helpers": "./packages/promise-helpers/src/index.ts"
+    "@whatwg-node/fetch": "./packages/fetch/dist/esm-ponyfill.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prebuild": "yarn clean-dist",
     "prerelease": "yarn build",
     "prerelease-canary": "yarn build",
+    "pretest:deno": "yarn build",
     "prettier": "prettier --ignore-path .gitignore --ignore-path .prettierignore --write --list-different .",
     "prettier:check": "prettier --ignore-path .gitignore --ignore-path .prettierignore --check .",
     "release": "changeset publish",

--- a/packages/promise-helpers/src/index.ts
+++ b/packages/promise-helpers/src/index.ts
@@ -109,7 +109,11 @@ export { iterateAsync as iterateAsyncVoid };
 
 export function iterateAsync<TInput, TOutput>(
   iterable: Iterable<TInput>,
-  callback: (input: TInput, endEarly: VoidFunction, index: number) => MaybePromise<TOutput>,
+  callback: (
+    input: TInput,
+    endEarly: VoidFunction,
+    index: number,
+  ) => MaybePromise<TOutput | undefined | null>,
   results?: TOutput[],
 ): MaybePromise<void> {
   if ((iterable as Array<TInput>)?.length === 0) {

--- a/packages/promise-helpers/src/index.ts
+++ b/packages/promise-helpers/src/index.ts
@@ -113,7 +113,7 @@ export function iterateAsync<TInput, TOutput>(
     input: TInput,
     endEarly: VoidFunction,
     index: number,
-  ) => MaybePromise<TOutput | undefined | null>,
+  ) => MaybePromise<TOutput | undefined | null | void>,
   results?: TOutput[],
 ): MaybePromise<void> {
   if ((iterable as Array<TInput>)?.length === 0) {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,7 +34,7 @@
   },
   "typings": "dist/typings/index.d.ts",
   "dependencies": {
-    "@envelop/instruments": "1.0.0-alpha-20250227114734-64d7083775b6c1ee4ce365437ae5f77c33aee3a5",
+    "@envelop/instruments": "1.0.0-alpha-20250227122402-42e2fa806ec3b7c2936e612924b153a20c8662c3",
     "@whatwg-node/disposablestack": "^0.0.6",
     "@whatwg-node/fetch": "^0.10.5",
     "@whatwg-node/promise-helpers": "^1.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,7 +34,7 @@
   },
   "typings": "dist/typings/index.d.ts",
   "dependencies": {
-    "@envelop/instruments": "^5.0.3",
+    "@envelop/instruments": "1.0.0-alpha-20250227114734-64d7083775b6c1ee4ce365437ae5f77c33aee3a5",
     "@whatwg-node/disposablestack": "^0.0.6",
     "@whatwg-node/fetch": "^0.10.5",
     "@whatwg-node/promise-helpers": "^1.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,6 +34,7 @@
   },
   "typings": "dist/typings/index.d.ts",
   "dependencies": {
+    "@envelop/instruments": "^5.0.3",
     "@whatwg-node/disposablestack": "^0.0.6",
     "@whatwg-node/fetch": "^0.10.5",
     "@whatwg-node/promise-helpers": "^1.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,7 +34,7 @@
   },
   "typings": "dist/typings/index.d.ts",
   "dependencies": {
-    "@envelop/instruments": "1.0.0-alpha-20250227122402-42e2fa806ec3b7c2936e612924b153a20c8662c3",
+    "@envelop/instruments": "1.0.0",
     "@whatwg-node/disposablestack": "^0.0.6",
     "@whatwg-node/fetch": "^0.10.5",
     "@whatwg-node/promise-helpers": "^1.0.0",

--- a/packages/server/src/createServerAdapter.ts
+++ b/packages/server/src/createServerAdapter.ts
@@ -1,16 +1,13 @@
-import { chain, getInstrumented } from "@envelop/instruments";
+import { chain, getInstrumented } from '@envelop/instruments';
+import { AsyncDisposableStack, DisposableSymbols } from '@whatwg-node/disposablestack';
+import * as DefaultFetchAPI from '@whatwg-node/fetch';
+import { handleMaybePromise, MaybePromise } from '@whatwg-node/promise-helpers';
 import {
-  AsyncDisposableStack,
-  DisposableSymbols,
-} from "@whatwg-node/disposablestack";
-import * as DefaultFetchAPI from "@whatwg-node/fetch";
-import { handleMaybePromise, MaybePromise } from "@whatwg-node/promise-helpers";
-import {
+  Instruments,
   OnRequestHook,
   OnResponseHook,
   ServerAdapterPlugin,
-  Instruments,
-} from "./plugins/types.js";
+} from './plugins/types.js';
 import {
   FetchAPI,
   FetchEvent,
@@ -19,7 +16,7 @@ import {
   ServerAdapterObject,
   ServerAdapterRequestHandler,
   type ServerAdapterInitialContext,
-} from "./types.js";
+} from './types.js';
 import {
   completeAssign,
   ensureDisposableStackRegisteredForTerminateEvents,
@@ -37,7 +34,7 @@ import {
   NodeResponse,
   normalizeNodeRequest,
   sendNodeResponse,
-} from "./utils.js";
+} from './utils.js';
 import {
   fakePromise,
   getRequestFromUWSRequest,
@@ -45,14 +42,12 @@ import {
   sendResponseToUwsOpts,
   type UWSRequest,
   type UWSResponse,
-} from "./uwebsockets.js";
+} from './uwebsockets.js';
 
 type RequestContainer = { request: Request };
 
 // Required for envs like nextjs edge runtime
-function isRequestAccessible(
-  serverContext: any
-): serverContext is RequestContainer {
+function isRequestAccessible(serverContext: any): serverContext is RequestContainer {
   try {
     return !!serverContext?.request;
   } catch {
@@ -77,47 +72,42 @@ const EMPTY_OBJECT = {};
 
 function createServerAdapter<
   TServerContext = {},
-  THandleRequest extends ServerAdapterRequestHandler<TServerContext> = ServerAdapterRequestHandler<TServerContext>
+  THandleRequest extends
+    ServerAdapterRequestHandler<TServerContext> = ServerAdapterRequestHandler<TServerContext>,
 >(
   serverAdapterRequestHandler: THandleRequest,
-  options?: ServerAdapterOptions<TServerContext>
-): ServerAdapter<
-  TServerContext,
-  ServerAdapterBaseObject<TServerContext, THandleRequest>
->;
+  options?: ServerAdapterOptions<TServerContext>,
+): ServerAdapter<TServerContext, ServerAdapterBaseObject<TServerContext, THandleRequest>>;
 function createServerAdapter<
   TServerContext,
-  TBaseObject extends ServerAdapterBaseObject<TServerContext>
+  TBaseObject extends ServerAdapterBaseObject<TServerContext>,
 >(
   serverAdapterBaseObject: TBaseObject,
-  options?: ServerAdapterOptions<TServerContext>
+  options?: ServerAdapterOptions<TServerContext>,
 ): ServerAdapter<TServerContext, TBaseObject>;
 function createServerAdapter<
   TServerContext = {},
-  THandleRequest extends ServerAdapterRequestHandler<TServerContext> = ServerAdapterRequestHandler<TServerContext>,
+  THandleRequest extends
+    ServerAdapterRequestHandler<TServerContext> = ServerAdapterRequestHandler<TServerContext>,
   TBaseObject extends ServerAdapterBaseObject<
     TServerContext,
     THandleRequest
-  > = ServerAdapterBaseObject<TServerContext, THandleRequest>
+  > = ServerAdapterBaseObject<TServerContext, THandleRequest>,
 >(
   serverAdapterBaseObject: TBaseObject | THandleRequest,
-  options?: ServerAdapterOptions<TServerContext>
+  options?: ServerAdapterOptions<TServerContext>,
 ): ServerAdapter<TServerContext, TBaseObject> {
   const fetchAPI = {
     ...DefaultFetchAPI,
     ...options?.fetchAPI,
   };
   const givenHandleRequest =
-    typeof serverAdapterBaseObject === "function"
+    typeof serverAdapterBaseObject === 'function'
       ? serverAdapterBaseObject
       : serverAdapterBaseObject.handle;
 
-  const onRequestHooks: OnRequestHook<
-    TServerContext & ServerAdapterInitialContext
-  >[] = [];
-  const onResponseHooks: OnResponseHook<
-    TServerContext & ServerAdapterInitialContext
-  >[] = [];
+  const onRequestHooks: OnRequestHook<TServerContext & ServerAdapterInitialContext>[] = [];
+  const onResponseHooks: OnResponseHook<TServerContext & ServerAdapterInitialContext>[] = [];
   let instruments: Instruments | undefined;
   const waitUntilPromises = new Set<PromiseLike<unknown>>();
   let _disposableStack: AsyncDisposableStack | undefined;
@@ -135,7 +125,7 @@ function createServerAdapter<
             },
             () => {
               waitUntilPromises.clear();
-            }
+            },
           );
         }
       });
@@ -152,12 +142,10 @@ function createServerAdapter<
         () => {
           waitUntilPromises.delete(promiseLike);
         },
-        (err) => {
-          console.error(
-            `Unexpected error while waiting: ${err.message || err}`
-          );
+        err => {
+          console.error(`Unexpected error while waiting: ${err.message || err}`);
           waitUntilPromises.delete(promiseLike);
-        }
+        },
       );
     }
   }
@@ -165,9 +153,7 @@ function createServerAdapter<
   if (options?.plugins != null) {
     for (const plugin of options.plugins) {
       if (plugin.instruments) {
-        instruments = instruments
-          ? chain(instruments, plugin.instruments)
-          : plugin.instruments;
+        instruments = instruments ? chain(instruments, plugin.instruments) : plugin.instruments;
       }
       if (plugin.onRequest) {
         onRequestHooks.push(plugin.onRequest);
@@ -189,22 +175,19 @@ function createServerAdapter<
     }
   }
 
-  let handleRequest: ServerAdapterRequestHandler<
-    TServerContext & ServerAdapterInitialContext
-  > =
+  let handleRequest: ServerAdapterRequestHandler<TServerContext & ServerAdapterInitialContext> =
     onRequestHooks.length > 0 || onResponseHooks.length > 0
       ? function handleRequest(request, serverContext) {
-          let requestHandler: ServerAdapterRequestHandler<any> =
-            givenHandleRequest;
+          let requestHandler: ServerAdapterRequestHandler<any> = givenHandleRequest;
           let response: Response | undefined;
           if (onRequestHooks.length === 0) {
             return handleEarlyResponse();
           }
           let url =
-            (request as any)["parsedUrl"] ||
+            (request as any)['parsedUrl'] ||
             (new Proxy(EMPTY_OBJECT as URL, {
               get(_target, prop, _receiver) {
-                url = new fetchAPI.URL(request.url, "http://localhost");
+                url = new fetchAPI.URL(request.url, 'http://localhost');
                 return Reflect.get(url, prop, url);
               },
             }) as URL);
@@ -214,7 +197,7 @@ function createServerAdapter<
             }
             return handleMaybePromise(
               () =>
-                iterateAsyncVoid(onResponseHooks, (onResponseHook) =>
+                iterateAsyncVoid(onResponseHooks, onResponseHook =>
                   onResponseHook({
                     request,
                     response,
@@ -223,16 +206,16 @@ function createServerAdapter<
                       response = newResponse;
                     },
                     fetchAPI,
-                  })
+                  }),
                 ),
-              () => response
+              () => response,
             );
           }
           function handleEarlyResponse() {
             if (!response) {
               return handleMaybePromise(
                 () => requestHandler(request, serverContext),
-                handleResponse
+                handleResponse,
               );
             }
             return handleResponse(response);
@@ -258,9 +241,9 @@ function createServerAdapter<
                       stopEarly();
                     }
                   },
-                })
+                }),
               ),
-            handleEarlyResponse
+            handleEarlyResponse,
           );
         }
       : givenHandleRequest;
@@ -268,20 +251,16 @@ function createServerAdapter<
   if (instruments?.request) {
     const originalRequestHandler = handleRequest;
     handleRequest = (request, initialContext) => {
-      return getInstrumented({ request }).asyncFn(
-        instruments.request,
-        originalRequestHandler
-      )(request, initialContext);
+      return getInstrumented({ request }).asyncFn(instruments.request, originalRequestHandler)(
+        request,
+        initialContext,
+      );
     };
   }
 
   // TODO: Remove this on the next major version
-  function handleNodeRequest(
-    nodeRequest: NodeRequest,
-    ...ctx: Partial<TServerContext>[]
-  ) {
-    const serverContext =
-      ctx.length > 1 ? completeAssign(...ctx) : ctx[0] || {};
+  function handleNodeRequest(nodeRequest: NodeRequest, ...ctx: Partial<TServerContext>[]) {
+    const serverContext = ctx.length > 1 ? completeAssign(...ctx) : ctx[0] || {};
     // Ensure `waitUntil` is available in the server context
     if (!serverContext.waitUntil) {
       serverContext.waitUntil = waitUntil;
@@ -319,34 +298,27 @@ function createServerAdapter<
               nodeRequest,
               nodeResponse,
               defaultServerContext as any,
-              ...ctx
+              ...ctx,
             ),
-          (response) => response,
-          (err) => handleErrorFromRequestHandler(err, fetchAPI.Response)
+          response => response,
+          err => handleErrorFromRequestHandler(err, fetchAPI.Response),
         ),
-      (response) =>
+      response =>
         handleMaybePromise(
           () => sendNodeResponse(response, nodeResponse, nodeRequest),
-          (r) => r,
-          (err) =>
-            console.error(
-              `Unexpected error while handling request: ${err.message || err}`
-            )
-        )
+          r => r,
+          err => console.error(`Unexpected error while handling request: ${err.message || err}`),
+        ),
     );
   }
 
-  function handleUWS(
-    res: UWSResponse,
-    req: UWSRequest,
-    ...ctx: Partial<TServerContext>[]
-  ) {
+  function handleUWS(res: UWSResponse, req: UWSRequest, ...ctx: Partial<TServerContext>[]) {
     const defaultServerContext = {
       res,
       req,
       waitUntil,
     };
-    const filteredCtxParts = ctx.filter((partCtx) => partCtx != null);
+    const filteredCtxParts = ctx.filter(partCtx => partCtx != null);
     const serverContext =
       filteredCtxParts.length > 0
         ? completeAssign(defaultServerContext, ...ctx)
@@ -364,7 +336,7 @@ function createServerAdapter<
       controller.abort();
     });
     res.onAborted = function (cb: () => void) {
-      controller.signal.addEventListener("abort", cb, { once: true });
+      controller.signal.addEventListener('abort', cb, { once: true });
     };
     const request = getRequestFromUWSRequest({
       req,
@@ -376,33 +348,28 @@ function createServerAdapter<
       () =>
         handleMaybePromise(
           () => handleRequest(request, serverContext),
-          (response) => response,
-          (err) => handleErrorFromRequestHandler(err, fetchAPI.Response)
+          response => response,
+          err => handleErrorFromRequestHandler(err, fetchAPI.Response),
         ),
-      (response) => {
+      response => {
         if (!controller.signal.aborted && !resEnded) {
           return handleMaybePromise(
             () => sendResponseToUwsOpts(res, response, controller, fetchAPI),
-            (r) => r,
-            (err) => {
-              console.error(
-                `Unexpected error while handling request: ${err.message || err}`
-              );
-            }
+            r => r,
+            err => {
+              console.error(`Unexpected error while handling request: ${err.message || err}`);
+            },
           );
         }
-      }
+      },
     );
   }
 
-  function handleEvent(
-    event: FetchEvent,
-    ...ctx: Partial<TServerContext>[]
-  ): void {
+  function handleEvent(event: FetchEvent, ...ctx: Partial<TServerContext>[]): void {
     if (!event.respondWith || !event.request) {
       throw new TypeError(`Expected FetchEvent, got ${event}`);
     }
-    const filteredCtxParts = ctx.filter((partCtx) => partCtx != null);
+    const filteredCtxParts = ctx.filter(partCtx => partCtx != null);
     const serverContext =
       filteredCtxParts.length > 0
         ? completeAssign({}, event, ...filteredCtxParts)
@@ -411,11 +378,8 @@ function createServerAdapter<
     event.respondWith(response$);
   }
 
-  function handleRequestWithWaitUntil(
-    request: Request,
-    ...ctx: Partial<TServerContext>[]
-  ) {
-    const filteredCtxParts: any[] = ctx.filter((partCtx) => partCtx != null);
+  function handleRequestWithWaitUntil(request: Request, ...ctx: Partial<TServerContext>[]) {
+    const filteredCtxParts: any[] = ctx.filter(partCtx => partCtx != null);
     const serverContext =
       filteredCtxParts.length > 1
         ? completeAssign({}, ...filteredCtxParts)
@@ -423,16 +387,16 @@ function createServerAdapter<
             filteredCtxParts[0],
             filteredCtxParts[0] == null || filteredCtxParts[0].waitUntil == null
               ? waitUntil
-              : undefined
+              : undefined,
           );
     return handleRequest(request, serverContext);
   }
 
-  const fetchFn: ServerAdapterObject<TServerContext>["fetch"] = (
+  const fetchFn: ServerAdapterObject<TServerContext>['fetch'] = (
     input,
     ...maybeCtx: Partial<TServerContext>[]
   ) => {
-    if (typeof input === "string" || "href" in input) {
+    if (typeof input === 'string' || 'href' in input) {
       const [initOrCtx, ...restOfCtx] = maybeCtx;
       if (isRequestInit(initOrCtx)) {
         const request = new fetchAPI.Request(input, initOrCtx);
@@ -474,7 +438,7 @@ function createServerAdapter<
     }
 
     if (isServerResponse(initOrCtxOrRes)) {
-      throw new TypeError("Got Node response without Node request");
+      throw new TypeError('Got Node response without Node request');
     }
 
     // Is input a container object over Request?
@@ -500,8 +464,7 @@ function createServerAdapter<
     requestListener,
     handleEvent,
     handleUWS,
-    handle:
-      genericRequestHandler as ServerAdapterObject<TServerContext>["handle"],
+    handle: genericRequestHandler as ServerAdapterObject<TServerContext>['handle'],
     get disposableStack() {
       return ensureDisposableStack();
     },
@@ -544,15 +507,11 @@ function createServerAdapter<
         return handleProp;
       }
       if (serverAdapterBaseObject) {
-        const serverAdapterBaseObjectProp = (serverAdapterBaseObject as any)[
-          prop
-        ];
+        const serverAdapterBaseObjectProp = (serverAdapterBaseObject as any)[prop];
         if (serverAdapterBaseObjectProp) {
           if (serverAdapterBaseObjectProp.bind) {
             return function (...args: any[]) {
-              const returnedVal = (serverAdapterBaseObject as any)[prop](
-                ...args
-              );
+              const returnedVal = (serverAdapterBaseObject as any)[prop](...args);
               if (returnedVal === serverAdapterBaseObject) {
                 return serverAdapter;
               }
@@ -563,11 +522,7 @@ function createServerAdapter<
         }
       }
     },
-    apply(
-      _,
-      __,
-      args: Parameters<ServerAdapterObject<TServerContext>["handle"]>
-    ) {
+    apply(_, __, args: Parameters<ServerAdapterObject<TServerContext>['handle']>) {
       return genericRequestHandler(...args);
     },
   });

--- a/packages/server/src/createServerAdapter.ts
+++ b/packages/server/src/createServerAdapter.ts
@@ -251,7 +251,7 @@ function createServerAdapter<
     const originalRequestHandler = handleRequest;
     handleRequest = (request, initialContext) => {
       let response: Promise<Response> | Response;
-      const tracerPromise = tracer.request({ request }, () => {
+      const tracerPromise = tracer!.request!({ request }, () => {
         response = originalRequestHandler(request, initialContext);
         return isPromise(response) ? response.then(() => undefined) : undefined;
       });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,3 +8,4 @@ export * from './plugins/useContentEncoding.js';
 export * from './uwebsockets.js';
 export { Response } from '@whatwg-node/fetch';
 export { DisposableSymbols } from '@whatwg-node/disposablestack';
+export * from '@envelop/instruments';

--- a/packages/server/src/plugins/types.ts
+++ b/packages/server/src/plugins/types.ts
@@ -10,7 +10,7 @@ export interface ServerAdapterPlugin<TServerContext = {}> {
    * A tracer insance. It can be used to wrap the entire request handling pipeline (including the
    * plugin hooks). It is mostly used for observability (monitoring, tracing, etc...).
    */
-  tracer: Tracer;
+  tracer?: Tracer;
   /**
    * This hook is invoked for ANY incoming HTTP request. Here you can manipulate the request,
    * create a short circuit before the request handler takes it over.

--- a/packages/server/src/plugins/types.ts
+++ b/packages/server/src/plugins/types.ts
@@ -2,14 +2,14 @@ import {
   FetchAPI,
   ServerAdapterRequestHandler,
   type ServerAdapterInitialContext,
-} from '../types.js';
+} from "../types.js";
 
 export interface ServerAdapterPlugin<TServerContext = {}> {
   /**
    * A tracer insance. It can be used to wrap the entire request handling pipeline (including the
    * plugin hooks). It is mostly used for observability (monitoring, tracing, etc...).
    */
-  tracer?: Tracer;
+  instruments?: Instruments;
   /**
    * This hook is invoked for ANY incoming HTTP request. Here you can manipulate the request,
    * create a short circuit before the request handler takes it over.
@@ -49,15 +49,15 @@ export interface ServerAdapterPlugin<TServerContext = {}> {
   onDispose?: () => PromiseLike<void> | void;
 }
 
-export type Tracer = {
+export type Instruments = {
   request?: (
     payload: { request: Request },
-    wrapped: () => Promise<void> | void,
+    wrapped: () => Promise<void> | void
   ) => Promise<void> | void;
 };
 
 export type OnRequestHook<TServerContext> = (
-  payload: OnRequestEventPayload<TServerContext>,
+  payload: OnRequestEventPayload<TServerContext>
 ) => Promise<void> | void;
 
 export interface OnRequestEventPayload<TServerContext> {
@@ -66,13 +66,15 @@ export interface OnRequestEventPayload<TServerContext> {
   serverContext: TServerContext;
   fetchAPI: FetchAPI;
   requestHandler: ServerAdapterRequestHandler<TServerContext>;
-  setRequestHandler(newRequestHandler: ServerAdapterRequestHandler<TServerContext>): void;
+  setRequestHandler(
+    newRequestHandler: ServerAdapterRequestHandler<TServerContext>
+  ): void;
   endResponse(response: Response): void;
   url: URL;
 }
 
 export type OnResponseHook<TServerContext> = (
-  payload: OnResponseEventPayload<TServerContext>,
+  payload: OnResponseEventPayload<TServerContext>
 ) => Promise<void> | void;
 
 export interface OnResponseEventPayload<TServerContext> {

--- a/packages/server/src/plugins/types.ts
+++ b/packages/server/src/plugins/types.ts
@@ -50,6 +50,13 @@ export interface ServerAdapterPlugin<TServerContext = {}> {
 }
 
 export type Instruments = {
+  /**
+   * Run code befor, after or around the handling of each request.
+   * This instrument can't modify result or paramters of the request handling.
+   * To have access to the input or the output of the request handling, use the `onRequest` hook.
+   *
+   * Note: The `wrapped` function must be called, otherwise the request will not be handled properly
+   */
   request?: (
     payload: { request: Request },
     wrapped: () => Promise<void> | void,

--- a/packages/server/src/plugins/types.ts
+++ b/packages/server/src/plugins/types.ts
@@ -50,7 +50,7 @@ export interface ServerAdapterPlugin<TServerContext = {}> {
 }
 
 export type Tracer = {
-  request: (
+  request?: (
     payload: { request: Request },
     wrapped: () => Promise<void> | void,
   ) => Promise<void> | void;

--- a/packages/server/src/plugins/types.ts
+++ b/packages/server/src/plugins/types.ts
@@ -2,7 +2,7 @@ import {
   FetchAPI,
   ServerAdapterRequestHandler,
   type ServerAdapterInitialContext,
-} from "../types.js";
+} from '../types.js';
 
 export interface ServerAdapterPlugin<TServerContext = {}> {
   /**
@@ -52,12 +52,12 @@ export interface ServerAdapterPlugin<TServerContext = {}> {
 export type Instruments = {
   request?: (
     payload: { request: Request },
-    wrapped: () => Promise<void> | void
+    wrapped: () => Promise<void> | void,
   ) => Promise<void> | void;
 };
 
 export type OnRequestHook<TServerContext> = (
-  payload: OnRequestEventPayload<TServerContext>
+  payload: OnRequestEventPayload<TServerContext>,
 ) => Promise<void> | void;
 
 export interface OnRequestEventPayload<TServerContext> {
@@ -66,15 +66,13 @@ export interface OnRequestEventPayload<TServerContext> {
   serverContext: TServerContext;
   fetchAPI: FetchAPI;
   requestHandler: ServerAdapterRequestHandler<TServerContext>;
-  setRequestHandler(
-    newRequestHandler: ServerAdapterRequestHandler<TServerContext>
-  ): void;
+  setRequestHandler(newRequestHandler: ServerAdapterRequestHandler<TServerContext>): void;
   endResponse(response: Response): void;
   url: URL;
 }
 
 export type OnResponseHook<TServerContext> = (
-  payload: OnResponseEventPayload<TServerContext>
+  payload: OnResponseEventPayload<TServerContext>,
 ) => Promise<void> | void;
 
 export interface OnResponseEventPayload<TServerContext> {

--- a/packages/server/src/plugins/types.ts
+++ b/packages/server/src/plugins/types.ts
@@ -1,3 +1,4 @@
+import { MaybePromise } from 'packages/disposablestack/src/utils.js';
 import {
   FetchAPI,
   ServerAdapterRequestHandler,
@@ -5,6 +6,11 @@ import {
 } from '../types.js';
 
 export interface ServerAdapterPlugin<TServerContext = {}> {
+  /**
+   * A tracer insance. It can be used to wrap the entire request handling pipeline (including the
+   * plugin hooks). It is mostly used for observability (monitoring, tracing, etc...).
+   */
+  tracer: Tracer;
   /**
    * This hook is invoked for ANY incoming HTTP request. Here you can manipulate the request,
    * create a short circuit before the request handler takes it over.
@@ -43,6 +49,14 @@ export interface ServerAdapterPlugin<TServerContext = {}> {
    */
   onDispose?: () => PromiseLike<void> | void;
 }
+
+export type Tracer = {
+  request: (
+    payload: { request: Request },
+    wrapped: () => Promise<void> | void,
+  ) => Promise<void> | void;
+};
+
 export type OnRequestHook<TServerContext> = (
   payload: OnRequestEventPayload<TServerContext>,
 ) => Promise<void> | void;

--- a/packages/server/src/plugins/types.ts
+++ b/packages/server/src/plugins/types.ts
@@ -1,4 +1,3 @@
-import { MaybePromise } from 'packages/disposablestack/src/utils.js';
 import {
   FetchAPI,
   ServerAdapterRequestHandler,

--- a/packages/server/test/instruments.spec.ts
+++ b/packages/server/test/instruments.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from '@jest/globals';
+import { createServerAdapter, ServerAdapterPlugin } from '@whatwg-node/server';
+
+describe('instruments', () => {
+  it('should wrap request handler with instruments and automatically compose them', async () => {
+    const results: string[] = [];
+
+    function make(name: string): ServerAdapterPlugin {
+      return {
+        instruments: {
+          request: async (_, wrapped) => {
+            results.push(`pre-${name}`);
+            await wrapped();
+            results.push(`post-${name}`);
+          },
+        },
+      };
+    }
+
+    const adapter = createServerAdapter<{}>(
+      () => {
+        results.push('request');
+        return Response.json({ message: 'Hello, World!' });
+      },
+      {
+        plugins: [make('1'), make('2'), make('3')],
+      },
+    );
+
+    await adapter.fetch('http://whatwg-node/graphql');
+    expect(results).toEqual(['pre-1', 'pre-2', 'pre-3', 'request', 'post-3', 'post-2', 'post-1']);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,10 +1235,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@envelop/instruments@1.0.0-alpha-20250227122402-42e2fa806ec3b7c2936e612924b153a20c8662c3":
-  version "1.0.0-alpha-20250227122402-42e2fa806ec3b7c2936e612924b153a20c8662c3"
-  resolved "https://registry.yarnpkg.com/@envelop/instruments/-/instruments-1.0.0-alpha-20250227122402-42e2fa806ec3b7c2936e612924b153a20c8662c3.tgz#8b846cc6196099c2101ed677a2f314200fe7c82c"
-  integrity sha512-wQMnsTP7QNetaBoScS1Uz7sGnX6MCULZuYub5uB05hnLcwGv/ByylWuIpoD7iEMXM1zvK/hPKCbP31NOzw2p+A==
+"@envelop/instruments@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@envelop/instruments/-/instruments-1.0.0.tgz#7e36926b6212048258ce1939bcf5a52e2a5dbe4d"
+  integrity sha512-f4lHoti7QgUIluIGTM0mG9Wf9/w6zc1mosYmyFkrApeHSP2PIUC6a8fMoqkdk6pgVOps39kLdIhOPF8pIKS8/A==
   dependencies:
     "@whatwg-node/promise-helpers" "^1.2.1"
     tslib "^2.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,10 +1235,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@envelop/instruments@^5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@envelop/instruments/-/instruments-5.0.3.tgz#94b28145916aea22db3d2f3714cc555db3f02916"
-  integrity sha512-89BC6LPo6UYR/8+RmeyxOSjr18bQ+2NxREvieexyA9zn8P5qXbTPUK+sW3kHznkPYfV4RDrkrmw81sjedQ0fyA==
+"@envelop/instruments@1.0.0-alpha-20250227114734-64d7083775b6c1ee4ce365437ae5f77c33aee3a5":
+  version "1.0.0-alpha-20250227114734-64d7083775b6c1ee4ce365437ae5f77c33aee3a5"
+  resolved "https://registry.yarnpkg.com/@envelop/instruments/-/instruments-1.0.0-alpha-20250227114734-64d7083775b6c1ee4ce365437ae5f77c33aee3a5.tgz#f39c4e0561d5b57501093e02b720897b13036263"
+  integrity sha512-/TR3ZLdmmxiAvyR/0Wjk1x530PT7sYfSyVrNjrX7bwU0/RKo9IDasa75Viehj+G/IlrMg2pdg6JedFnZ2ztvGA==
   dependencies:
     "@whatwg-node/promise-helpers" "^1.2.1"
     tslib "^2.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,6 +1235,14 @@
   dependencies:
     tslib "^2.4.0"
 
+"@envelop/instruments@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@envelop/instruments/-/instruments-5.0.3.tgz#94b28145916aea22db3d2f3714cc555db3f02916"
+  integrity sha512-89BC6LPo6UYR/8+RmeyxOSjr18bQ+2NxREvieexyA9zn8P5qXbTPUK+sW3kHznkPYfV4RDrkrmw81sjedQ0fyA==
+  dependencies:
+    "@whatwg-node/promise-helpers" "^1.2.1"
+    tslib "^2.5.0"
+
 "@esbuild-plugins/node-globals-polyfill@0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz#0e4497a2b53c9e9485e149bc92ddb228438d6bcf"
@@ -7700,7 +7708,6 @@ mvdan-sh@^0.10.1:
 
 "nan@github:JCMais/nan#fix/electron-failures":
   version "2.22.0"
-  uid "0ec2eca8b2fd7518affb3945d087e393ad839b7e"
   resolved "https://codeload.github.com/JCMais/nan/tar.gz/0ec2eca8b2fd7518affb3945d087e393ad839b7e"
 
 nanoid@^3.3.6:
@@ -9767,7 +9774,7 @@ tslib@2.6.2:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.6.3, tslib@^2.8.0:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.2, tslib@^2.6.3, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -9873,7 +9880,6 @@ typescript@5.7.3:
 
 uWebSockets.js@uNetworking/uWebSockets.js#v20.51.0:
   version "20.51.0"
-  uid "6609a88ffa9a16ac5158046761356ce03250a0df"
   resolved "https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/6609a88ffa9a16ac5158046761356ce03250a0df"
 
 ufo@^1.5.4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1235,10 +1235,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@envelop/instruments@1.0.0-alpha-20250227114734-64d7083775b6c1ee4ce365437ae5f77c33aee3a5":
-  version "1.0.0-alpha-20250227114734-64d7083775b6c1ee4ce365437ae5f77c33aee3a5"
-  resolved "https://registry.yarnpkg.com/@envelop/instruments/-/instruments-1.0.0-alpha-20250227114734-64d7083775b6c1ee4ce365437ae5f77c33aee3a5.tgz#f39c4e0561d5b57501093e02b720897b13036263"
-  integrity sha512-/TR3ZLdmmxiAvyR/0Wjk1x530PT7sYfSyVrNjrX7bwU0/RKo9IDasa75Viehj+G/IlrMg2pdg6JedFnZ2ztvGA==
+"@envelop/instruments@1.0.0-alpha-20250227122402-42e2fa806ec3b7c2936e612924b153a20c8662c3":
+  version "1.0.0-alpha-20250227122402-42e2fa806ec3b7c2936e612924b153a20c8662c3"
+  resolved "https://registry.yarnpkg.com/@envelop/instruments/-/instruments-1.0.0-alpha-20250227122402-42e2fa806ec3b7c2936e612924b153a20c8662c3.tgz#8b846cc6196099c2101ed677a2f314200fe7c82c"
+  integrity sha512-wQMnsTP7QNetaBoScS1Uz7sGnX6MCULZuYub5uB05hnLcwGv/ByylWuIpoD7iEMXM1zvK/hPKCbP31NOzw2p+A==
   dependencies:
     "@whatwg-node/promise-helpers" "^1.2.1"
     tslib "^2.5.0"


### PR DESCRIPTION

## Description

This PR is the continuation of https://github.com/n1ru4l/envelop/pull/2430 which introduces a new core API: The Tracer.

A plugin (and only one) can define a `tracer` instance that will wrap every phases of a request pipeline.

In the case of `wahtwg-node`, it only adds the `request` wrapper.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new Instruments API to enhance observability within the GraphQL pipeline.

- **Chores**
  - Streamlined project configuration by updating dependency management and refining build scripts.
  - Removed redundant external dependency imports for a cleaner setup.
  - Added new entries to `.gitignore` to prevent tracking of specific configuration files.
  - Introduced a new pre-test script for Deno build process.
  - Added a new test suite for the instruments functionality to verify request handler behavior.
  - Expanded callback return options in the `iterateAsync` function to include `undefined` or `null`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->