### PR TITLE
fix(node-fetch): reading `Headers.get('set-cookie')` when `_map` has not been initialised

### DIFF
--- a/packages/node-fetch/src/Headers.ts
+++ b/packages/node-fetch/src/Headers.ts
@@ -19,6 +19,8 @@ export class PonyfillHeaders implements Headers {
   private _get(key: string) {
     const normalized = key.toLowerCase();
     if (normalized === 'set-cookie') {
+      // this._setCookies is only set when this._map has been initialised
+      if (!this._map) this.getMap();
       return this._setCookies.join(', ');
     }
     // If the map is built, reuse it


### PR DESCRIPTION


Reading `Headers.get('set-cookie')` gives the initial value (empty array) until `getMap` is called

This PR fixes the bug

<!--
  Thanks for filing a pull request on WhatWG Node!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Related # (issue)

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `package-name`:
- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
