### PR TITLE
fix(node-fetch): respect `set-cookies` given in `HeadersInit`

### DIFF
--- a/.changeset/curvy-insects-cheer.md
+++ b/.changeset/curvy-insects-cheer.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/node-fetch': patch
+---
+
+Fix the bug when `set-cookies` given is ignored in `HeadersInit`

--- a/packages/node-fetch/tests/Headers.spec.ts
+++ b/packages/node-fetch/tests/Headers.spec.ts
@@ -62,13 +62,19 @@ describe('Headers', () => {
     expect(inspect(headers)).toBe("Headers { 'x-header': null }");
   });
   describe('Set-Cookie', () => {
-    it('handles values in the given map', () => {
-      const init = {
-        // Record<string, string[]> is not a HeadersInit actually
-        'set-cookie': ['a=b', 'c=d'],
-      } as any;
-      const headers = new PonyfillHeaders(init);
-      expect(headers.get('Set-Cookie')).toBe('a=b,c=d');
+    it('handles values in the given map for get method', () => {
+      const headers = new PonyfillHeaders([
+        ['set-cookie', 'a=b'],
+        ['set-cookie', 'c=d'],
+      ]);
+      expect(headers.get('Set-Cookie')).toBe('a=b, c=d');
+    });
+    it('handles values in the given map for getSetCookie method', () => {
+      const headers = new PonyfillHeaders([
+        ['set-cookie', 'a=b'],
+        ['set-cookie', 'c=d'],
+      ]);
+      expect(headers.getSetCookie()).toEqual(['a=b', 'c=d']);
     });
   });
 });

--- a/packages/node-fetch/tests/Headers.spec.ts
+++ b/packages/node-fetch/tests/Headers.spec.ts
@@ -61,4 +61,14 @@ describe('Headers', () => {
     headers.set('X-Header', null!);
     expect(inspect(headers)).toBe("Headers { 'x-header': null }");
   });
+  describe('Set-Cookie', () => {
+    it('handles values in the given map', () => {
+      const init = {
+        // Record<string, string[]> is not a HeadersInit actually
+        'set-cookie': ['a=b', 'c=d'],
+      } as any;
+      const headers = new PonyfillHeaders(init);
+      expect(headers.get('Set-Cookie')).toBe('a=b,c=d');
+    });
+  });
 });


### PR DESCRIPTION
Alternative to https://github.com/ardatan/whatwg-node/pull/2074
Closes https://github.com/ardatan/whatwg-node/issues/2076
Closes https://github.com/ardatan/whatwg-node/pull/2074
Completes WHATWG-63

Keeps the optimization logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of "set-cookie" headers, ensuring that multiple values are processed correctly for enhanced header management.
- **Tests**
	- Introduced new tests to validate the correct concatenation of cookie values and the accurate retrieval of individual "set-cookie" values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->