### PR TITLE
fix(node-fetch/http2): handle Http2 streams correctly

### DIFF
--- a/.changeset/mighty-worlds-smoke.md
+++ b/.changeset/mighty-worlds-smoke.md
@@ -1,0 +1,9 @@
+---
+'@whatwg-node/node-fetch': patch
+'@whatwg-node/server': patch
+'@whatwg-node/fetch': patch
+---
+
+Fix HTTP/2 body stream handling
+
+This fixes the `TypeError: bodyInit.stream is not a function` error thrown when the incoming request is attempted to parse.

--- a/.changeset/mighty-worlds-smoke.md
+++ b/.changeset/mighty-worlds-smoke.md
@@ -4,4 +4,4 @@
 '@whatwg-node/fetch': patch
 ---
 
-Fixes the `TypeError: bodyInit.stream is not a function` error thrown when the incoming HTTP/2 request is attempted to parse.
+Fixes the `TypeError: bodyInit.stream is not a function` error thrown when `@whatwg-node/server` attempts the incoming HTTP/2 request to parse with `Request.json`, `Request.text`, `Request.formData`, or `Request.blob` methods.

--- a/.changeset/mighty-worlds-smoke.md
+++ b/.changeset/mighty-worlds-smoke.md
@@ -4,6 +4,4 @@
 '@whatwg-node/fetch': patch
 ---
 
-Fix HTTP/2 body stream handling
-
-This fixes the `TypeError: bodyInit.stream is not a function` error thrown when the incoming request is attempted to parse.
+Fixes the `TypeError: bodyInit.stream is not a function` error thrown when the incoming HTTP/2 request is attempted to parse.

--- a/.changeset/mighty-worlds-smoke.md
+++ b/.changeset/mighty-worlds-smoke.md
@@ -4,4 +4,4 @@
 '@whatwg-node/fetch': patch
 ---
 
-Fixes the `TypeError: bodyInit.stream is not a function` error thrown when `@whatwg-node/server` attempts the incoming HTTP/2 request to parse with `Request.json`, `Request.text`, `Request.formData`, or `Request.blob` methods.
+Fixes the `TypeError: bodyInit.stream is not a function` error thrown when `@whatwg-node/server` is used with `node:http2` and attempts the incoming HTTP/2 request to parse with `Request.json`, `Request.text`, `Request.formData`, or `Request.blob` methods.

--- a/packages/node-fetch/src/Body.ts
+++ b/packages/node-fetch/src/Body.ts
@@ -508,7 +508,7 @@ function isFormData(value: any): value is FormData {
 }
 
 function isBlob(value: any): value is Blob {
-  return value?.stream != null;
+  return value?.stream != null && typeof value.stream === 'function';
 }
 
 function isURLSearchParams(value: any): value is URLSearchParams {


### PR DESCRIPTION
Fixes https://github.com/dotansimha/graphql-yoga/issues/3803

Fixes the bug; `TypeError: bodyInit.stream is not a function` error thrown when `@whatwg-node/server` is used with `node:http2` and attempts the incoming HTTP/2 request to parse with `Request.json`, `Request.text`, `Request.formData`, or `Request.blob` methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue causing errors during HTTP/2 request processing, ensuring reliable operation for various request methods.
  - Improved Blob validation to correctly identify and handle stream functionality.

- **Tests**
  - Updated HTTP/2 test cases to confirm that responses now include complete, structured details such as body, headers, method, and URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->