### PR TITLE
fix(server): Request.url access error on Bun & Express

### DIFF
--- a/.changeset/three-shirts-make.md
+++ b/.changeset/three-shirts-make.md
@@ -1,0 +1,6 @@
+---
+'@whatwg-node/server': patch
+---
+
+Fix the error `The Request.url getter can only be used on instances of Request` when the adapter is
+used with Express on Bun

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -166,7 +166,7 @@ export function normalizeNodeRequest(nodeRequest: NodeRequest, fetchAPI: FetchAP
       request.headers.set('content-type', 'application/json; charset=utf-8');
     }
     return new Proxy(request, {
-      get: (target, prop: keyof Request,receiver) => {
+      get: (target, prop: keyof Request, receiver) => {
         switch (prop) {
           case 'json':
             return () => fakePromise(maybeParsedBody);

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -166,14 +166,14 @@ export function normalizeNodeRequest(nodeRequest: NodeRequest, fetchAPI: FetchAP
       request.headers.set('content-type', 'application/json; charset=utf-8');
     }
     return new Proxy(request, {
-      get: (target, prop: keyof Request, receiver) => {
+      get: (_target, prop: keyof Request, _receiver) => {
         switch (prop) {
           case 'json':
             return () => fakePromise(maybeParsedBody);
           case 'text':
             return () => fakePromise(JSON.stringify(maybeParsedBody));
           default:
-            return Reflect.get(target, prop, receiver);
+            return Reflect.get(request, prop, request);
         }
       },
     });

--- a/packages/server/test/reproductions.spec.ts
+++ b/packages/server/test/reproductions.spec.ts
@@ -1,5 +1,5 @@
-import { Server } from 'http';
-import { AddressInfo } from 'net';
+import { Server } from 'node:http';
+import { AddressInfo } from 'node:net';
 import express from 'express';
 import { expect, it } from '@jest/globals';
 import { createServerAdapter, Response } from '@whatwg-node/server';

--- a/packages/server/test/reproductions.spec.ts
+++ b/packages/server/test/reproductions.spec.ts
@@ -1,0 +1,44 @@
+import { Server } from 'http';
+import { AddressInfo } from 'net';
+import express from 'express';
+import { expect, it } from '@jest/globals';
+import { createServerAdapter, Response } from '@whatwg-node/server';
+
+it('bun issue#12368', async () => {
+  const app = express();
+
+  app.use(express.json({ limit: '1mb' }));
+
+  const echoAdapter = createServerAdapter(req =>
+    req.json().then(body =>
+      Response.json({
+        body,
+        url: req.url,
+      }),
+    ),
+  );
+
+  app.use('/my-path', echoAdapter);
+
+  const server = await new Promise<Server>((resolve, reject) => {
+    const server = app.listen(0, err => (err ? reject(err) : resolve(server)));
+  });
+
+  const port = (server.address() as AddressInfo).port;
+
+  const response = await fetch(`http://localhost:${port}/my-path`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ hello: 'world' }),
+  });
+
+  const bodyText = await response.text();
+  expect(bodyText).toEqual(
+    JSON.stringify({
+      body: { hello: 'world' },
+      url: `http://localhost:${port}/my-path`,
+    }),
+  );
+});

--- a/packages/server/test/reproductions.spec.ts
+++ b/packages/server/test/reproductions.spec.ts
@@ -1,9 +1,17 @@
 import { Server } from 'node:http';
 import { AddressInfo } from 'node:net';
 import express from 'express';
-import { expect, it } from '@jest/globals';
+import { afterAll, expect, it } from '@jest/globals';
 import { createServerAdapter, Response } from '@whatwg-node/server';
 
+let server: Server | undefined;
+afterAll(() => {
+  if (server) {
+    return new Promise<void>((resolve, reject) =>
+      server?.close(err => (err ? reject(err) : resolve())),
+    );
+  }
+});
 it('bun issue#12368', async () => {
   const app = express();
 
@@ -20,7 +28,7 @@ it('bun issue#12368', async () => {
 
   app.use('/my-path', echoAdapter);
 
-  const server = await new Promise<Server>((resolve, reject) => {
+  server = await new Promise<Server>((resolve, reject) => {
     const server = app.listen(0, err => (err ? reject(err) : resolve(server)));
   });
 


### PR DESCRIPTION
Workaround for a potential bug in Bun itself, this might cause issues if the created Proxy's methods are used within another scope/`this`, but most of cases are fine. So the change is applied only for Bun.

Fixes https://github.com/oven-sh/bun/issues/12368#issuecomment-2689392673
Fixes https://github.com/dotansimha/graphql-yoga/issues/3446

Ref WHATWG-65

It seems Bun doesn't pass the right `receiver` in Proxy.get so `Reflect.get`'s `receiver` doesn't work properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a runtime error affecting request handling when using the Express framework on the Bun runtime.
  - Improved compatibility in Bun environments by refining how request data is accessed.
  
- **Tests**
  - Introduced automated tests to confirm correct handling of JSON requests and responses under these conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->