### PR TITLE
Add Node 16 to promise-helpers to prevent breaking change on dependent Tools packages

### DIFF
--- a/.changeset/metal-feet-attack.md
+++ b/.changeset/metal-feet-attack.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/promise-helpers': patch
+---
+
+Use Node 16 at least to prevent breaking change on dependent Tools packages

--- a/packages/promise-helpers/package.json
+++ b/packages/promise-helpers/package.json
@@ -11,7 +11,7 @@
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=16.0.0"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Fixes https://github.com/ardatan/graphql-tools/issues/6983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated overall compatibility requirements to support Node.js version 16 and newer, broadening the runtime support.
  
- **Tests**
	- Expanded the automated test configuration to run on Node.js 16 alongside the previously supported versions.
	- Adjusted the 'Native' test suite criteria to ensure it only runs in compatible environments.
	- Enhanced control flow in the `Node Specific Cases` test suite to conditionally execute tests based on the availability of `ReadableStream`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->