### PR TITLE
feat(promise-helpers): add `finally` callback to `handleMaybePromise`

### DIFF
--- a/.changeset/late-flies-bet.md
+++ b/.changeset/late-flies-bet.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/promise-helpers': minor
+---
+
+Allow to pass a finally callback to `handleMaybePromise`

--- a/deno-jest.ts
+++ b/deno-jest.ts
@@ -8,7 +8,7 @@ it.each =
       Object.entries(c).forEach(([k, v]) => {
         name = name.replaceAll(k, v);
       });
-      return it(name, runner);
+      return it(name, () => runner(c));
     }
   };
 export { it };

--- a/deno-jest.ts
+++ b/deno-jest.ts
@@ -11,17 +11,8 @@ export {
 } from 'jsr:@std/testing/bdd';
 export { expect } from 'jsr:@std/expect';
 
-const mocks: { mockClear: () => void }[] = [];
-
 export const jest = {
-  fn<T extends (...args: any[]) => any>(implementation?: T) {
-    const f = fn(implementation);
-    mocks.push(f);
-    return f;
-  },
-  clearAllMocks: () => {
-    mocks.forEach(mock => mock.mockClear());
-  },
+  fn,
   spyOn(target: any, method: string) {
     Object.defineProperty(target, method, {
       value: fn(target[method]),

--- a/deno-jest.ts
+++ b/deno-jest.ts
@@ -11,8 +11,17 @@ export {
 } from 'jsr:@std/testing/bdd';
 export { expect } from 'jsr:@std/expect';
 
+const mocks: { mockClear: () => void }[] = [];
+
 export const jest = {
-  fn,
+  fn<T extends (...args: any[]) => any>(implementation?: T) {
+    const f = fn(implementation);
+    mocks.push(f);
+    return f;
+  },
+  clearAllMocks: () => {
+    mocks.forEach(mock => mock.mockClear());
+  },
   spyOn(target: any, method: string) {
     Object.defineProperty(target, method, {
       value: fn(target[method]),

--- a/deno-jest.ts
+++ b/deno-jest.ts
@@ -5,10 +5,11 @@ it.each =
   (cases: object[]): typeof it =>
   (name, runner) => {
     for (const c of cases) {
+      let testName = name;
       Object.entries(c).forEach(([k, v]) => {
-        name = name.replaceAll(k, v);
+        testName = testName.replaceAll(k, v);
       });
-      return it(name, () => runner(c));
+      it(testName, () => runner(c));
     }
   };
 export { it };

--- a/deno-jest.ts
+++ b/deno-jest.ts
@@ -1,14 +1,19 @@
 import { fn } from 'jsr:@std/expect';
+import { it } from 'jsr:@std/testing/bdd';
 
-export {
-  describe,
-  it,
-  test,
-  beforeEach,
-  afterEach,
-  beforeAll,
-  afterAll,
-} from 'jsr:@std/testing/bdd';
+it.each =
+  (cases: object[]): typeof it =>
+  (name, runner) => {
+    for (const c of cases) {
+      Object.entries(c).forEach(([k, v]) => {
+        name = name.replaceAll(k, v);
+      });
+      return it(name, runner);
+    }
+  };
+export { it };
+
+export { describe, test, beforeEach, afterEach, beforeAll, afterAll } from 'jsr:@std/testing/bdd';
 export { expect } from 'jsr:@std/expect';
 
 export const jest = {

--- a/packages/promise-helpers/src/index.ts
+++ b/packages/promise-helpers/src/index.ts
@@ -30,19 +30,7 @@ export function handleMaybePromise<TInput, TOutput>(
   outputErrorFactory?: (err: any) => MaybePromiseLike<TOutput>,
   finallyFactory?: () => MaybePromiseLike<void>,
 ): MaybePromiseLike<TOutput> {
-  let input$: MaybePromise<TInput> | undefined;
-  try {
-    input$ = fakePromise(inputFactory());
-  } catch (err) {
-    input$ = fakeRejectPromise(err);
-  }
-
-  let result$: Promise<TOutput>;
-  try {
-    result$ = input$.then(outputSuccessFactory, outputErrorFactory);
-  } catch (err) {
-    result$ = fakeRejectPromise(err);
-  }
+  let result$ = fakePromise().then(inputFactory).then(outputSuccessFactory, outputErrorFactory);
 
   if (finallyFactory) {
     result$ = result$.finally(finallyFactory);

--- a/packages/promise-helpers/src/index.ts
+++ b/packages/promise-helpers/src/index.ts
@@ -36,15 +36,7 @@ export function handleMaybePromise<TInput, TOutput>(
     result$ = result$.finally(finallyFactory);
   }
 
-  if (isFakePromise<TOutput>(result$)) {
-    return result$.__fakePromiseValue;
-  }
-
-  if (isFakeRejectPromise(result$)) {
-    throw result$.__fakeRejectError;
-  }
-
-  return result$;
+  return unfakePromise(result$);
 }
 
 export function fakePromise<T>(value: MaybePromise<T>): Promise<T>;
@@ -350,4 +342,16 @@ export function promiseLikeFinally<T>(
       }
     },
   );
+}
+
+export function unfakePromise<T>(promise: Promise<T>): MaybePromise<T> {
+  if (isFakePromise<T>(promise)) {
+    return promise.__fakePromiseValue;
+  }
+
+  if (isFakeRejectPromise(promise)) {
+    throw promise.__fakeRejectError;
+  }
+
+  return promise;
 }

--- a/packages/promise-helpers/src/index.ts
+++ b/packages/promise-helpers/src/index.ts
@@ -1,6 +1,8 @@
 export type MaybePromise<T> = Promise<T> | T;
 export type MaybePromiseLike<T> = PromiseLike<T> | T;
 
+const FAKE_PROMISE_SYMBOL_NAME = '@whatwg-node/promise-helpers/FakePromise';
+
 export function isPromise<T>(value: MaybePromise<T>): value is Promise<T>;
 export function isPromise<T>(value: MaybePromiseLike<T>): value is PromiseLike<T>;
 export function isPromise<T>(value: MaybePromiseLike<T>): value is PromiseLike<T> {
@@ -87,6 +89,7 @@ export function fakePromise<T>(value: MaybePromiseLike<T>): Promise<T> {
     },
     [Symbol.toStringTag]: 'Promise',
     __fakePromiseValue: value,
+    [Symbol.for(FAKE_PROMISE_SYMBOL_NAME)]: 'resolved',
   } as Promise<T>;
 }
 
@@ -194,6 +197,7 @@ export function fakeRejectPromise<T>(error: unknown): Promise<T> {
     },
     __fakeRejectError: error,
     [Symbol.toStringTag]: 'Promise',
+    [Symbol.for(FAKE_PROMISE_SYMBOL_NAME)]: 'rejected',
   } as Promise<never>;
 }
 
@@ -311,11 +315,11 @@ function iteratorResult<T>(value: T): IteratorResult<T> {
 }
 
 function isFakePromise<T>(value: any): value is Promise<T> & { __fakePromiseValue: T } {
-  return (value as any)?.__fakePromiseValue != null;
+  return (value as any)?.[Symbol.for(FAKE_PROMISE_SYMBOL_NAME)] === 'resolved';
 }
 
 function isFakeRejectPromise(value: any): value is Promise<never> & { __fakeRejectError: any } {
-  return (value as any)?.__fakeRejectError != null;
+  return (value as any)?.[Symbol.for(FAKE_PROMISE_SYMBOL_NAME)] === 'rejected';
 }
 
 export function promiseLikeFinally<T>(

--- a/packages/promise-helpers/src/index.ts
+++ b/packages/promise-helpers/src/index.ts
@@ -61,8 +61,9 @@ export function handleMaybePromise<TInput, TOutput>(
 
 export function fakePromise<T>(value: MaybePromise<T>): Promise<T>;
 export function fakePromise<T>(value: MaybePromiseLike<T>): Promise<T>;
+export function fakePromise(value: void): Promise<void>;
 export function fakePromise<T>(value: MaybePromiseLike<T>): Promise<T> {
-  if (isActualPromise(value)) {
+  if (value && isActualPromise(value)) {
     return value;
   }
 
@@ -78,7 +79,7 @@ export function fakePromise<T>(value: MaybePromiseLike<T>): Promise<T> {
   // Write a fake promise to avoid the promise constructor
   // being called with `new Promise` in the browser.
   return {
-    then(resolve: (value: T) => any) {
+    then(resolve) {
       if (resolve) {
         const callbackResult = resolve(value);
         if (isPromise(callbackResult)) {

--- a/packages/promise-helpers/src/index.ts
+++ b/packages/promise-helpers/src/index.ts
@@ -81,11 +81,11 @@ export function fakePromise<T>(value: MaybePromiseLike<T>): Promise<T> {
   return {
     then(resolve) {
       if (resolve) {
-        const callbackResult = resolve(value);
-        if (isPromise(callbackResult)) {
-          return callbackResult;
+        try {
+          return fakePromise(resolve(value));
+        } catch (err) {
+          return fakeRejectPromise(err);
         }
-        return fakePromise(callbackResult);
       }
       return this;
     },
@@ -94,14 +94,14 @@ export function fakePromise<T>(value: MaybePromiseLike<T>): Promise<T> {
     },
     finally(cb) {
       if (cb) {
-        const callbackResult = cb();
-        if (isPromise(callbackResult)) {
-          return callbackResult.then(
+        try {
+          return fakePromise(cb()).then(
             () => value,
             () => value,
           );
+        } catch (err) {
+          return fakeRejectPromise(err);
         }
-        return fakePromise(value);
       }
       return this;
     },
@@ -184,19 +184,31 @@ export function fakeRejectPromise<T>(error: unknown): Promise<T> {
   return {
     then(_resolve, reject) {
       if (reject) {
-        return fakePromise(reject(error));
+        try {
+          return fakePromise(reject(error));
+        } catch (err) {
+          return fakeRejectPromise(err);
+        }
       }
       return this;
     },
     catch(reject: (error: unknown) => any) {
       if (reject) {
-        return fakePromise(reject(error));
+        try {
+          return fakePromise(reject(error));
+        } catch (err) {
+          return fakeRejectPromise(err);
+        }
       }
       return this;
     },
     finally(cb) {
       if (cb) {
-        cb();
+        try {
+          cb();
+        } catch (err) {
+          return fakeRejectPromise(err);
+        }
       }
       return this;
     },

--- a/packages/promise-helpers/src/index.ts
+++ b/packages/promise-helpers/src/index.ts
@@ -7,6 +7,11 @@ export function isPromise<T>(value: MaybePromiseLike<T>): value is PromiseLike<T
   return (value as any)?.then != null;
 }
 
+export function isActualPromise<T>(value: MaybePromiseLike<T>): value is Promise<T> {
+  const maybePromise = value as any;
+  return maybePromise && maybePromise.then && maybePromise.catch && maybePromise.finally;
+}
+
 export function handleMaybePromise<TInput, TOutput>(
   inputFactory: () => MaybePromise<TInput>,
   outputSuccessFactory: (value: TInput) => MaybePromise<TOutput>,
@@ -25,14 +30,14 @@ export function handleMaybePromise<TInput, TOutput>(
   outputErrorFactory?: (err: any) => MaybePromiseLike<TOutput>,
   finallyFactory?: () => MaybePromiseLike<void>,
 ): MaybePromiseLike<TOutput> {
-  let input$: MaybePromiseLike<TInput> | undefined;
+  let input$: MaybePromise<TInput> | undefined;
   try {
     input$ = fakePromise(inputFactory());
   } catch (err) {
     input$ = fakeRejectPromise(err);
   }
 
-  let result$: PromiseLike<TOutput>;
+  let result$: Promise<TOutput>;
   try {
     result$ = input$.then(outputSuccessFactory, outputErrorFactory);
   } catch (err) {
@@ -40,7 +45,7 @@ export function handleMaybePromise<TInput, TOutput>(
   }
 
   if (finallyFactory) {
-    result$ = promiseLikeFinally(result$, finallyFactory);
+    result$ = result$.finally(finallyFactory);
   }
 
   if (isFakePromise<TOutput>(result$)) {
@@ -54,12 +59,22 @@ export function handleMaybePromise<TInput, TOutput>(
   return result$;
 }
 
-export function fakePromise<T>(value: T): Promise<Awaited<T>>;
-export function fakePromise(value: void): Promise<void>;
-export function fakePromise<T = void>(value: T): Promise<T> {
-  if (isPromise(value)) {
+export function fakePromise<T>(value: MaybePromise<T>): Promise<T>;
+export function fakePromise<T>(value: MaybePromiseLike<T>): Promise<T>;
+export function fakePromise<T>(value: MaybePromiseLike<T>): Promise<T> {
+  if (isActualPromise(value)) {
     return value;
   }
+
+  if (isPromise(value)) {
+    return {
+      then: (resolve, reject) => fakePromise(value.then(resolve, reject)),
+      catch: reject => fakePromise(value.then(res => res, reject)),
+      finally: cb => fakePromise(cb ? promiseLikeFinally(value, cb) : value),
+      [Symbol.toStringTag]: 'Promise',
+    };
+  }
+
   // Write a fake promise to avoid the promise constructor
   // being called with `new Promise` in the browser.
   return {
@@ -164,10 +179,7 @@ export function iterateAsync<TInput, TOutput>(
   return iterate();
 }
 
-export function fakeRejectPromise(error: unknown): Promise<never> {
-  if (isPromise(error)) {
-    return error as Promise<never>;
-  }
+export function fakeRejectPromise<T>(error: unknown): Promise<T> {
   return {
     then(_resolve, reject) {
       if (reject) {
@@ -313,7 +325,7 @@ function isFakeRejectPromise(value: any): value is Promise<never> & { __fakeReje
   return (value as any)?.__fakeRejectError != null;
 }
 
-function promiseLikeFinally<T>(
+export function promiseLikeFinally<T>(
   value: PromiseLike<T> | Promise<T>,
   onFinally: () => MaybePromiseLike<void>,
 ): PromiseLike<T> {

--- a/packages/promise-helpers/tests/handleMaybePromise.spec.ts
+++ b/packages/promise-helpers/tests/handleMaybePromise.spec.ts
@@ -140,7 +140,7 @@ describe('promise-helpers', () => {
         });
 
         it('should call finally even if onSuccess is rejected', async () => {
-          onSuccess.mockRejectedValueOnce('error');
+          onSuccess = jest.fn(() => Promise.reject('error'));
           await expect(
             handleMaybePromise(() => Promise.resolve('test'), onSuccess, onError, onFinally),
           ).rejects.toBe('error');
@@ -150,7 +150,7 @@ describe('promise-helpers', () => {
         });
 
         it('should call finally even if onError is rejected', async () => {
-          onError.mockRejectedValueOnce('error');
+          onError = jest.fn(() => Promise.reject('error'));
           await expect(
             handleMaybePromise(() => Promise.reject('test'), onSuccess, onError, onFinally),
           ).rejects.toBe('error');
@@ -203,7 +203,7 @@ describe('promise-helpers', () => {
         });
 
         it('should call finally even if onSuccess throws', async () => {
-          onSuccess.mockImplementationOnce(() => {
+          onSuccess = jest.fn(() => {
             throw 'error';
           });
           await expect(
@@ -215,7 +215,7 @@ describe('promise-helpers', () => {
         });
 
         it('should call finally even if onError throws', async () => {
-          onError.mockImplementationOnce(() => {
+          onError = jest.fn(() => {
             throw 'error';
           });
           await expect(
@@ -268,7 +268,7 @@ describe('promise-helpers', () => {
         });
 
         it('should call finally even if onSuccess throws', async () => {
-          onSuccess.mockReturnValueOnce(fakeRejectPromise('error'));
+          onSuccess = jest.fn(() => fakeRejectPromise('error'));
           await expect(
             handleMaybePromise(() => Promise.resolve('test'), onSuccess, onError, onFinally),
           ).rejects.toBe('error');
@@ -278,7 +278,7 @@ describe('promise-helpers', () => {
         });
 
         it('should call finally even if onError throws', async () => {
-          onError.mockReturnValueOnce(fakeRejectPromise('error'));
+          onError = jest.fn(() => fakeRejectPromise('error'));
           await expect(
             handleMaybePromise(() => Promise.reject('test'), onSuccess, onError, onFinally),
           ).rejects.toBe('error');

--- a/packages/promise-helpers/tests/handleMaybePromise.spec.ts
+++ b/packages/promise-helpers/tests/handleMaybePromise.spec.ts
@@ -103,14 +103,14 @@ describe('promise-helpers', () => {
     });
     describe('finally', () => {
       describe('with promises', () => {
-        const onFinally = jest.fn(() => Promise.resolve());
-        const onError = jest.fn(err => Promise.resolve(err));
-        const onSuccess = jest.fn(res => Promise.resolve(res));
+        let onFinally: jest.MockedFunction<any>;
+        let onError: jest.MockedFunction<any>;
+        let onSuccess: jest.MockedFunction<any>;
 
         beforeEach(() => {
-          onFinally.mockClear();
-          onSuccess.mockClear();
-          onError.mockClear();
+          onFinally = jest.fn(() => Promise.resolve());
+          onError = jest.fn(err => Promise.resolve(err));
+          onSuccess = jest.fn(res => Promise.resolve(res));
         });
 
         it('should call finally and allow chaining with a successful Promise', async () => {
@@ -161,14 +161,14 @@ describe('promise-helpers', () => {
       });
 
       describe('with sync function', () => {
-        const onFinally = jest.fn(() => {});
-        const onError = jest.fn(err => err);
-        const onSuccess = jest.fn(res => res);
+        let onFinally: jest.Mock<VoidFunction>;
+        let onError: jest.Mock;
+        let onSuccess: jest.Mock;
 
         beforeEach(() => {
-          onFinally.mockClear();
-          onSuccess.mockClear();
-          onError.mockClear();
+          onFinally = jest.fn(() => {});
+          onError = jest.fn(err => err);
+          onSuccess = jest.fn(res => res);
         });
 
         it('should call finally and allow chaining with a successful function', () => {

--- a/packages/promise-helpers/tests/handleMaybePromise.spec.ts
+++ b/packages/promise-helpers/tests/handleMaybePromise.spec.ts
@@ -194,12 +194,12 @@ describe('promise-helpers', () => {
           };
           try {
             handleMaybePromise(throwingFn, onSuccess, undefined, onFinally);
+            throw 'Error was not thrown';
           } catch (err) {
             expect(err).toBe('error');
           }
           expect(onFinally).toHaveBeenCalledTimes(1);
           expect(onSuccess).not.toHaveBeenCalled();
-          expect.assertions(3);
         });
 
         it('should call finally even if onSuccess throws', async () => {
@@ -259,12 +259,12 @@ describe('promise-helpers', () => {
         it('should call finally and allow throw if no error handler is given', async () => {
           try {
             handleMaybePromise(() => fakeRejectPromise('error'), onSuccess, undefined, onFinally);
+            throw 'Error has not been thrown';
           } catch (err) {
             expect(err).toBe('error');
           }
           expect(onFinally).toHaveBeenCalledTimes(1);
           expect(onSuccess).not.toHaveBeenCalled();
-          expect.assertions(3);
         });
 
         it('should call finally even if onSuccess throws', async () => {

--- a/packages/promise-helpers/tests/handleMaybePromise.spec.ts
+++ b/packages/promise-helpers/tests/handleMaybePromise.spec.ts
@@ -3,18 +3,16 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { fakePromise, fakeRejectPromise, handleMaybePromise } from '../src';
 
 describe('promise-helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('handleMaybePromise', () => {
     describe('finally', () => {
       describe('with promises', () => {
         const onFinally = jest.fn(() => Promise.resolve());
         const onError = jest.fn(err => Promise.resolve(err));
         const onSuccess = jest.fn(res => Promise.resolve(res));
-
-        beforeEach(() => {
-          onFinally.mockClear();
-          onSuccess.mockClear();
-          onError.mockClear();
-        });
 
         it('should call finally and allow chaining with a successful Promise', async () => {
           expect(
@@ -67,12 +65,6 @@ describe('promise-helpers', () => {
         const onFinally = jest.fn(() => {});
         const onError = jest.fn(err => err);
         const onSuccess = jest.fn(res => res);
-
-        beforeEach(() => {
-          onFinally.mockClear();
-          onSuccess.mockClear();
-          onError.mockClear();
-        });
 
         it('should call finally and allow chaining with a successful function', () => {
           expect(handleMaybePromise(() => 'test', onSuccess, onError, onFinally)).toBe('test');
@@ -134,12 +126,6 @@ describe('promise-helpers', () => {
         const onFinally = jest.fn(() => {});
         const onError = jest.fn(err => fakePromise(err));
         const onSuccess = jest.fn(res => fakePromise(res));
-
-        beforeEach(() => {
-          onFinally.mockClear();
-          onSuccess.mockClear();
-          onError.mockClear();
-        });
 
         it('should call finally and allow chaining on successful fake promise', () => {
           expect(handleMaybePromise(() => fakePromise('test'), onSuccess, onError, onFinally)).toBe(

--- a/packages/promise-helpers/tests/handleMaybePromise.spec.ts
+++ b/packages/promise-helpers/tests/handleMaybePromise.spec.ts
@@ -3,16 +3,18 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { fakePromise, fakeRejectPromise, handleMaybePromise } from '../src';
 
 describe('promise-helpers', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe('handleMaybePromise', () => {
     describe('finally', () => {
       describe('with promises', () => {
         const onFinally = jest.fn(() => Promise.resolve());
         const onError = jest.fn(err => Promise.resolve(err));
         const onSuccess = jest.fn(res => Promise.resolve(res));
+
+        beforeEach(() => {
+          onFinally.mockClear();
+          onSuccess.mockClear();
+          onError.mockClear();
+        });
 
         it('should call finally and allow chaining with a successful Promise', async () => {
           expect(
@@ -65,6 +67,12 @@ describe('promise-helpers', () => {
         const onFinally = jest.fn(() => {});
         const onError = jest.fn(err => err);
         const onSuccess = jest.fn(res => res);
+
+        beforeEach(() => {
+          onFinally.mockClear();
+          onSuccess.mockClear();
+          onError.mockClear();
+        });
 
         it('should call finally and allow chaining with a successful function', () => {
           expect(handleMaybePromise(() => 'test', onSuccess, onError, onFinally)).toBe('test');
@@ -126,6 +134,12 @@ describe('promise-helpers', () => {
         const onFinally = jest.fn(() => {});
         const onError = jest.fn(err => fakePromise(err));
         const onSuccess = jest.fn(res => fakePromise(res));
+
+        beforeEach(() => {
+          onFinally.mockClear();
+          onSuccess.mockClear();
+          onError.mockClear();
+        });
 
         it('should call finally and allow chaining on successful fake promise', () => {
           expect(handleMaybePromise(() => fakePromise('test'), onSuccess, onError, onFinally)).toBe(

--- a/packages/promise-helpers/tests/handleMaybePromise.spec.ts
+++ b/packages/promise-helpers/tests/handleMaybePromise.spec.ts
@@ -1,18 +1,18 @@
 /* eslint-disable prefer-promise-reject-errors, no-throw-literal */
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest as jestDoNotUse } from '@jest/globals';
 import { fakePromise, fakeRejectPromise, handleMaybePromise } from '../src';
 
 describe('promise-helpers', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    clearAllMocks();
   });
 
   describe('handleMaybePromise', () => {
     describe('finally', () => {
       describe('with promises', () => {
-        const onFinally = jest.fn(() => Promise.resolve());
-        const onError = jest.fn(err => Promise.resolve(err));
-        const onSuccess = jest.fn(res => Promise.resolve(res));
+        const onFinally = spy(() => Promise.resolve());
+        const onError = spy(err => Promise.resolve(err));
+        const onSuccess = spy(res => Promise.resolve(res));
 
         it('should call finally and allow chaining with a successful Promise', async () => {
           expect(
@@ -62,9 +62,9 @@ describe('promise-helpers', () => {
       });
 
       describe('with sync function', () => {
-        const onFinally = jest.fn(() => {});
-        const onError = jest.fn(err => err);
-        const onSuccess = jest.fn(res => res);
+        const onFinally = spy(() => {});
+        const onError = spy(err => err);
+        const onSuccess = spy(res => res);
 
         it('should call finally and allow chaining with a successful function', () => {
           expect(handleMaybePromise(() => 'test', onSuccess, onError, onFinally)).toBe('test');
@@ -123,9 +123,9 @@ describe('promise-helpers', () => {
       });
 
       describe('with fake promises', () => {
-        const onFinally = jest.fn(() => {});
-        const onError = jest.fn(err => fakePromise(err));
-        const onSuccess = jest.fn(res => fakePromise(res));
+        const onFinally = spy(() => {});
+        const onError = spy(err => fakePromise(err));
+        const onSuccess = spy(res => fakePromise(res));
 
         it('should call finally and allow chaining on successful fake promise', () => {
           expect(handleMaybePromise(() => fakePromise('test'), onSuccess, onError, onFinally)).toBe(
@@ -179,3 +179,16 @@ describe('promise-helpers', () => {
     });
   });
 });
+
+// Deno is missing `jest.mockClearAll`, so we have to implement it ourself
+
+const mocks: { mockClear: () => void }[] = [];
+function spy<T extends (...args: any) => any>(implementation: T) {
+  const f = jestDoNotUse.fn(implementation);
+  mocks.push(f);
+  return f;
+}
+
+function clearAllMocks() {
+  mocks.forEach(mock => mock.mockClear());
+}

--- a/packages/promise-helpers/tests/handleMaybePromise.spec.ts
+++ b/packages/promise-helpers/tests/handleMaybePromise.spec.ts
@@ -1,0 +1,36 @@
+/* eslint-disable prefer-promise-reject-errors */
+import { beforeEach } from 'node:test';
+import { describe, expect, it, jest } from '@jest/globals';
+import { handleMaybePromise } from '../src';
+
+describe('promise-helpers', () => {
+  describe('handleMaybePromise', () => {
+    describe('finally', () => {
+      const onFinally = jest.fn(() => Promise.resolve());
+      const onError = jest.fn(err => Promise.resolve(err));
+      const onSuccess = jest.fn(res => Promise.resolve(res));
+
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call finally and allow chaining with a successful Promise', async () => {
+        expect(
+          await handleMaybePromise(() => Promise.resolve('test'), onSuccess, onError, onFinally),
+        ).toBe('test');
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(onFinally).toHaveBeenCalledTimes(1);
+        expect(onError).not.toHaveBeenCalled();
+      });
+
+      it('should call finally and allow chaining with a fake promise', async () => {
+        expect(
+          await handleMaybePromise(() => Promise.reject('error'), onSuccess, onError, onFinally),
+        ).toBe('error');
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onFinally).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/packages/promise-helpers/tests/handleMaybePromise.spec.ts
+++ b/packages/promise-helpers/tests/handleMaybePromise.spec.ts
@@ -1,18 +1,20 @@
 /* eslint-disable prefer-promise-reject-errors, no-throw-literal */
-import { beforeEach, describe, expect, it, jest as jestDoNotUse } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { fakePromise, fakeRejectPromise, handleMaybePromise } from '../src';
 
 describe('promise-helpers', () => {
-  beforeEach(() => {
-    clearAllMocks();
-  });
-
   describe('handleMaybePromise', () => {
     describe('finally', () => {
       describe('with promises', () => {
-        const onFinally = spy(() => Promise.resolve());
-        const onError = spy(err => Promise.resolve(err));
-        const onSuccess = spy(res => Promise.resolve(res));
+        const onFinally = jest.fn(() => Promise.resolve());
+        const onError = jest.fn(err => Promise.resolve(err));
+        const onSuccess = jest.fn(res => Promise.resolve(res));
+
+        beforeEach(() => {
+          onFinally.mockClear();
+          onSuccess.mockClear();
+          onError.mockClear();
+        });
 
         it('should call finally and allow chaining with a successful Promise', async () => {
           expect(
@@ -62,9 +64,15 @@ describe('promise-helpers', () => {
       });
 
       describe('with sync function', () => {
-        const onFinally = spy(() => {});
-        const onError = spy(err => err);
-        const onSuccess = spy(res => res);
+        const onFinally = jest.fn(() => {});
+        const onError = jest.fn(err => err);
+        const onSuccess = jest.fn(res => res);
+
+        beforeEach(() => {
+          onFinally.mockClear();
+          onSuccess.mockClear();
+          onError.mockClear();
+        });
 
         it('should call finally and allow chaining with a successful function', () => {
           expect(handleMaybePromise(() => 'test', onSuccess, onError, onFinally)).toBe('test');
@@ -123,9 +131,15 @@ describe('promise-helpers', () => {
       });
 
       describe('with fake promises', () => {
-        const onFinally = spy(() => {});
-        const onError = spy(err => fakePromise(err));
-        const onSuccess = spy(res => fakePromise(res));
+        const onFinally = jest.fn(() => {});
+        const onError = jest.fn(err => fakePromise(err));
+        const onSuccess = jest.fn(res => fakePromise(res));
+
+        beforeEach(() => {
+          onFinally.mockClear();
+          onSuccess.mockClear();
+          onError.mockClear();
+        });
 
         it('should call finally and allow chaining on successful fake promise', () => {
           expect(handleMaybePromise(() => fakePromise('test'), onSuccess, onError, onFinally)).toBe(
@@ -179,16 +193,3 @@ describe('promise-helpers', () => {
     });
   });
 });
-
-// Deno is missing `jest.mockClearAll`, so we have to implement it ourself
-
-const mocks: { mockClear: () => void }[] = [];
-function spy<T extends (...args: any) => any>(implementation: T) {
-  const f = jestDoNotUse.fn(implementation);
-  mocks.push(f);
-  return f;
-}
-
-function clearAllMocks() {
-  mocks.forEach(mock => mock.mockClear());
-}

--- a/packages/promise-helpers/tests/handleMaybePromise.spec.ts
+++ b/packages/promise-helpers/tests/handleMaybePromise.spec.ts
@@ -1,35 +1,180 @@
-/* eslint-disable prefer-promise-reject-errors */
-import { beforeEach } from 'node:test';
-import { describe, expect, it, jest } from '@jest/globals';
-import { handleMaybePromise } from '../src';
+/* eslint-disable prefer-promise-reject-errors, no-throw-literal */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { fakePromise, fakeRejectPromise, handleMaybePromise } from '../src';
 
 describe('promise-helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('handleMaybePromise', () => {
     describe('finally', () => {
-      const onFinally = jest.fn(() => Promise.resolve());
-      const onError = jest.fn(err => Promise.resolve(err));
-      const onSuccess = jest.fn(res => Promise.resolve(res));
+      describe('with promises', () => {
+        const onFinally = jest.fn(() => Promise.resolve());
+        const onError = jest.fn(err => Promise.resolve(err));
+        const onSuccess = jest.fn(res => Promise.resolve(res));
 
-      beforeEach(() => {
-        jest.clearAllMocks();
+        it('should call finally and allow chaining with a successful Promise', async () => {
+          expect(
+            await handleMaybePromise(() => Promise.resolve('test'), onSuccess, onError, onFinally),
+          ).toBe('test');
+          expect(onSuccess).toHaveBeenCalledTimes(1);
+          expect(onFinally).toHaveBeenCalledTimes(1);
+          expect(onError).not.toHaveBeenCalled();
+        });
+
+        it('should call finally and allow chaining with a fake promise', async () => {
+          expect(
+            await handleMaybePromise(() => Promise.reject('error'), onSuccess, onError, onFinally),
+          ).toBe('error');
+          expect(onError).toHaveBeenCalledTimes(1);
+          expect(onFinally).toHaveBeenCalledTimes(1);
+          expect(onSuccess).not.toHaveBeenCalled();
+        });
+
+        it('should call finally and allow reject if no error handler is given', async () => {
+          await expect(
+            handleMaybePromise(() => Promise.reject('error'), onSuccess, undefined, onFinally),
+          ).rejects.toBe('error');
+          expect(onFinally).toHaveBeenCalledTimes(1);
+          expect(onSuccess).not.toHaveBeenCalled();
+        });
+
+        it('should call finally even if onSuccess is rejected', async () => {
+          onSuccess.mockRejectedValueOnce('error');
+          await expect(
+            handleMaybePromise(() => Promise.resolve('test'), onSuccess, onError, onFinally),
+          ).rejects.toBe('error');
+          expect(onFinally).toHaveReturnedTimes(1);
+          expect(onSuccess).toHaveBeenCalledTimes(1);
+          expect(onError).not.toHaveBeenCalled();
+        });
+
+        it('should call finally even if onError is rejected', async () => {
+          onError.mockRejectedValueOnce('error');
+          await expect(
+            handleMaybePromise(() => Promise.reject('test'), onSuccess, onError, onFinally),
+          ).rejects.toBe('error');
+          expect(onFinally).toHaveReturnedTimes(1);
+          expect(onError).toHaveBeenCalledTimes(1);
+          expect(onSuccess).not.toHaveBeenCalled();
+        });
       });
 
-      it('should call finally and allow chaining with a successful Promise', async () => {
-        expect(
-          await handleMaybePromise(() => Promise.resolve('test'), onSuccess, onError, onFinally),
-        ).toBe('test');
-        expect(onSuccess).toHaveBeenCalledTimes(1);
-        expect(onFinally).toHaveBeenCalledTimes(1);
-        expect(onError).not.toHaveBeenCalled();
+      describe('with sync function', () => {
+        const onFinally = jest.fn(() => {});
+        const onError = jest.fn(err => err);
+        const onSuccess = jest.fn(res => res);
+
+        it('should call finally and allow chaining with a successful function', () => {
+          expect(handleMaybePromise(() => 'test', onSuccess, onError, onFinally)).toBe('test');
+          expect(onFinally).toHaveBeenCalledTimes(1);
+          expect(onSuccess).toHaveBeenCalledTimes(1);
+          expect(onError).not.toHaveBeenCalled();
+        });
+
+        it('should call finally and allow chaining with a throwing function', () => {
+          const throwingFn = () => {
+            throw 'error';
+          };
+          expect(handleMaybePromise(throwingFn, onSuccess, onError, onFinally)).toBe('error');
+          expect(onFinally).toHaveBeenCalledTimes(1);
+          expect(onError).toHaveBeenCalledTimes(1);
+          expect(onSuccess).not.toHaveBeenCalled();
+        });
+
+        it('should call finally and allow throw if no error handler is given', async () => {
+          const throwingFn = () => {
+            throw 'error';
+          };
+          try {
+            handleMaybePromise(throwingFn, onSuccess, undefined, onFinally);
+          } catch (err) {
+            expect(err).toBe('error');
+          }
+          expect(onFinally).toHaveBeenCalledTimes(1);
+          expect(onSuccess).not.toHaveBeenCalled();
+          expect.assertions(3);
+        });
+
+        it('should call finally even if onSuccess throws', async () => {
+          onSuccess.mockImplementationOnce(() => {
+            throw 'error';
+          });
+          await expect(
+            handleMaybePromise(() => Promise.resolve('test'), onSuccess, onError, onFinally),
+          ).rejects.toBe('error');
+          expect(onFinally).toHaveReturnedTimes(1);
+          expect(onSuccess).toHaveBeenCalledTimes(1);
+          expect(onError).not.toHaveBeenCalled();
+        });
+
+        it('should call finally even if onError throws', async () => {
+          onError.mockImplementationOnce(() => {
+            throw 'error';
+          });
+          await expect(
+            handleMaybePromise(() => Promise.reject('test'), onSuccess, onError, onFinally),
+          ).rejects.toBe('error');
+          expect(onFinally).toHaveReturnedTimes(1);
+          expect(onError).toHaveBeenCalledTimes(1);
+          expect(onSuccess).not.toHaveBeenCalled();
+        });
       });
 
-      it('should call finally and allow chaining with a fake promise', async () => {
-        expect(
-          await handleMaybePromise(() => Promise.reject('error'), onSuccess, onError, onFinally),
-        ).toBe('error');
-        expect(onSuccess).not.toHaveBeenCalled();
-        expect(onFinally).toHaveBeenCalledTimes(1);
-        expect(onError).toHaveBeenCalledTimes(1);
+      describe('with fake promises', () => {
+        const onFinally = jest.fn(() => {});
+        const onError = jest.fn(err => fakePromise(err));
+        const onSuccess = jest.fn(res => fakePromise(res));
+
+        it('should call finally and allow chaining on successful fake promise', () => {
+          expect(handleMaybePromise(() => fakePromise('test'), onSuccess, onError, onFinally)).toBe(
+            'test',
+          );
+          expect(onSuccess).toHaveBeenCalledTimes(1);
+          expect(onFinally).toHaveBeenCalledTimes(1);
+          expect(onError).not.toHaveBeenCalled();
+        });
+
+        it('should call finally and allow chaining on rejected fake promise', () => {
+          expect(
+            handleMaybePromise(() => fakeRejectPromise('error'), onSuccess, onError, onFinally),
+          ).toBe('error');
+          expect(onError).toHaveBeenCalledTimes(1);
+          expect(onFinally).toHaveBeenCalledTimes(1);
+          expect(onSuccess).not.toHaveBeenCalled();
+        });
+
+        it('should call finally and allow throw if no error handler is given', async () => {
+          try {
+            handleMaybePromise(() => fakeRejectPromise('error'), onSuccess, undefined, onFinally);
+          } catch (err) {
+            expect(err).toBe('error');
+          }
+          expect(onFinally).toHaveBeenCalledTimes(1);
+          expect(onSuccess).not.toHaveBeenCalled();
+          expect.assertions(3);
+        });
+
+        it('should call finally even if onSuccess throws', async () => {
+          onSuccess.mockReturnValueOnce(fakeRejectPromise('error'));
+          await expect(
+            handleMaybePromise(() => Promise.resolve('test'), onSuccess, onError, onFinally),
+          ).rejects.toBe('error');
+          expect(onFinally).toHaveReturnedTimes(1);
+          expect(onSuccess).toHaveBeenCalledTimes(1);
+          expect(onError).not.toHaveBeenCalled();
+        });
+
+        it('should call finally even if onError throws', async () => {
+          onError.mockReturnValueOnce(fakeRejectPromise('error'));
+          await expect(
+            handleMaybePromise(() => Promise.reject('test'), onSuccess, onError, onFinally),
+          ).rejects.toBe('error');
+          expect(onFinally).toHaveReturnedTimes(1);
+          expect(onError).toHaveBeenCalledTimes(1);
+          expect(onSuccess).not.toHaveBeenCalled();
+        });
       });
     });
   });

--- a/packages/promise-helpers/tests/handleMaybePromise.spec.ts
+++ b/packages/promise-helpers/tests/handleMaybePromise.spec.ts
@@ -228,14 +228,14 @@ describe('promise-helpers', () => {
       });
 
       describe('with fake promises', () => {
-        const onFinally = jest.fn(() => {});
-        const onError = jest.fn(err => fakePromise(err));
-        const onSuccess = jest.fn(res => fakePromise(res));
+        let onFinally: jest.Mock<VoidFunction>;
+        let onError: jest.Mock;
+        let onSuccess: jest.Mock;
 
         beforeEach(() => {
-          onFinally.mockClear();
-          onSuccess.mockClear();
-          onError.mockClear();
+          onFinally = jest.fn(() => {});
+          onSuccess = jest.fn(res => fakePromise(res));
+          onError = jest.fn(err => fakePromise(err));
         });
 
         it('should call finally and allow chaining on successful fake promise', () => {


### PR DESCRIPTION
This PR aims to ease the use of maybe async flows with handling of `finally`.

It contains 4 things:
 - `handleMaybePromise` can now take a `finallyFactory` that is guaranteed to always run, whatever happens in success or failure factories.
 - `fakePromise` previously could return a `PromiseLike` instead of a `Promise` (because of a weird unsound TS inference). It have been fix to know ponyfill Promise interface by only using `then` function of the provided `PromiseLike` object.
 - `fakeRejectPromise` no longer forward promises. Because it doesn't have much sense, this function should be used to fake a rejected promise, so the parameter should always be an error that will be encapsulated into a fake rejected promise
 - `fakeRejectPromise` and `fakePromise` are now safe against exceptions. This makes `handleMaybePromise` a bit obsolete, but it's way more easier to use classic promise chaining API than the callback style of `handleMaybePromise`
 - Added `unfakePromise` which turns a (possibly fake) `Promise` into a `MaybePromise` by extracting value or throwing error if the promise is fake.