### PR TITLE
fix(server): do not wait for `response.write` for `response.end`

### DIFF
--- a/.changeset/whole-planes-mate.md
+++ b/.changeset/whole-planes-mate.md
@@ -6,7 +6,7 @@ Some implementations like `compression` npm package do not implement `response.w
 Then it causes the response stream hangs when the compression package takes the stream over when the response data is larger than its threshold.
 
 It is actually a bug in `compression` package;
-[https://github.com/expressjs/compression/blob/master/index.js#L99](https://github.com/expressjs/compression/issues/46)
+[compression#46](https://github.com/expressjs/compression/issues/46)
 But since it is a common mistake, we prefer to workaround this on our end.
 
 So now the server adapter calls `response.end` immediately after `response.write` for static responses.

--- a/.changeset/whole-planes-mate.md
+++ b/.changeset/whole-planes-mate.md
@@ -2,10 +2,11 @@
 '@whatwg-node/server': patch
 ---
 
-Call response.end without waiting for `.write` because some implementations do not have callback in
-`response.write`
-
 Some implementations like `compression` npm package do not implement `response.write(data, callback)` signature, but whatwg-node/server waits for it to finish the response stream.
+Then it causes the response stream hangs when the compression package takes the stream over when the response data is larger than its threshold.
+
 It is actually a bug in `compression` package;
 https://github.com/expressjs/compression/blob/master/index.js#L99
 But since it is a common mistake, we prefer to workaround this on our end.
+
+So now the server adapter calls `response.end` immediately after `response.write` for static responses.

--- a/.changeset/whole-planes-mate.md
+++ b/.changeset/whole-planes-mate.md
@@ -11,4 +11,7 @@ It is actually a bug in `compression` package;
 [expressjs/compression#46](https://github.com/expressjs/compression/issues/46)
 But since it is a common mistake, we prefer to workaround this on our end.
 
-So now the server adapter calls `response.end` immediately after `response.write` for static responses.
+Now after calling `response.write`, it no longer uses callback but first it checks the result;
+
+if it is `true`, it means stream is drained and we can call `response.end` immediately.
+else if it is `false`, it means the stream is not drained yet, so we can wait for the `drain` event to call `response.end`.

--- a/.changeset/whole-planes-mate.md
+++ b/.changeset/whole-planes-mate.md
@@ -6,7 +6,7 @@ Some implementations like `compression` npm package do not implement `response.w
 Then it causes the response stream hangs when the compression package takes the stream over when the response data is larger than its threshold.
 
 It is actually a bug in `compression` package;
-[compression#46](https://github.com/expressjs/compression/issues/46)
+[expressjs/compression#46](https://github.com/expressjs/compression/issues/46)
 But since it is a common mistake, we prefer to workaround this on our end.
 
 So now the server adapter calls `response.end` immediately after `response.write` for static responses.

--- a/.changeset/whole-planes-mate.md
+++ b/.changeset/whole-planes-mate.md
@@ -1,0 +1,6 @@
+---
+'@whatwg-node/server': patch
+---
+
+Call response.end without waiting for `.write` because some implementations do not have callback in
+`response.write`

--- a/.changeset/whole-planes-mate.md
+++ b/.changeset/whole-planes-mate.md
@@ -6,7 +6,7 @@ Some implementations like `compression` npm package do not implement `response.w
 Then it causes the response stream hangs when the compression package takes the stream over when the response data is larger than its threshold.
 
 It is actually a bug in `compression` package;
-https://github.com/expressjs/compression/blob/master/index.js#L99
+[https://github.com/expressjs/compression/blob/master/index.js#L99](https://github.com/expressjs/compression/issues/46)
 But since it is a common mistake, we prefer to workaround this on our end.
 
 So now the server adapter calls `response.end` immediately after `response.write` for static responses.

--- a/.changeset/whole-planes-mate.md
+++ b/.changeset/whole-planes-mate.md
@@ -1,4 +1,6 @@
 ---
+'@whatwg-node/node-fetch': patch
+'@whatwg-node/fetch': patch
 '@whatwg-node/server': patch
 ---
 

--- a/.changeset/whole-planes-mate.md
+++ b/.changeset/whole-planes-mate.md
@@ -4,3 +4,8 @@
 
 Call response.end without waiting for `.write` because some implementations do not have callback in
 `response.write`
+
+Some implementations like `compression` npm package do not implement `response.write(data, callback)` signature, but whatwg-node/server waits for it to finish the response stream.
+It is actually a bug in `compression` package;
+https://github.com/expressjs/compression/blob/master/index.js#L99
+But since it is a common mistake, we prefer to workaround this on our end.

--- a/packages/node-fetch/src/FormData.ts
+++ b/packages/node-fetch/src/FormData.ts
@@ -96,7 +96,7 @@ export function getStreamFromFormData(
 ): PonyfillReadableStream<Uint8Array> {
   let entriesIterator: FormDataIterator<[string, FormDataEntryValue]>;
   let sentInitialHeader = false;
-  let currentAsyncIterator: AsyncIterator<[string, FormDataEntryValue]> | undefined;
+  let currentAsyncIterator: AsyncIterator<Uint8Array> | undefined;
   let hasBefore = false;
   function handleNextEntry(controller: ReadableStreamController<Buffer>) {
     const { done, value } = entriesIterator.next();
@@ -123,7 +123,8 @@ export function getStreamFromFormData(
         controller.enqueue(
           Buffer.from(`Content-Type: ${blobOrString.type || 'application/octet-stream'}\r\n\r\n`),
         );
-        const entryStream: any = blobOrString.stream();
+        const entryStream = blobOrString.stream();
+        // @ts-expect-error - ReadableStream is async iterable
         currentAsyncIterator = entryStream[Symbol.asyncIterator]();
       }
       hasBefore = true;

--- a/packages/node-fetch/src/TransformStream.ts
+++ b/packages/node-fetch/src/TransformStream.ts
@@ -1,5 +1,6 @@
 import { Transform } from 'node:stream';
 import { PonyfillReadableStream } from './ReadableStream.js';
+import { endStream } from './utils.js';
 import { PonyfillWritableStream } from './WritableStream.js';
 
 export class PonyfillTransformStream<I = any, O = any> implements TransformStream<I, O> {
@@ -19,7 +20,7 @@ export class PonyfillTransformStream<I = any, O = any> implements TransformStrea
           transform.destroy(reason);
         },
         terminate() {
-          transform.end();
+          endStream(transform);
         },
         get desiredSize() {
           return transform.writableLength;

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -70,3 +70,18 @@ export function wrapIncomingMessageWithPassthrough({
     .catch(onError);
   return passThrough;
 }
+
+export function endStream(stream: { end: () => void }) {
+  // @ts-expect-error Avoid arguments adaptor trampoline https://v8.dev/blog/adaptor-frame
+  return stream.end(null, null, null);
+}
+
+export function safeWrite(
+  chunk: any,
+  stream: { write: (chunk: any) => boolean; once: (event: string, listener: () => void) => void },
+) {
+  const result = stream.write(chunk);
+  if (!result) {
+    return new Promise<void>(resolve => stream.once('drain', resolve));
+  }
+}

--- a/packages/promise-helpers/src/index.ts
+++ b/packages/promise-helpers/src/index.ts
@@ -32,13 +32,36 @@ export function handleMaybePromise<TInput, TOutput>(
   outputErrorFactory?: (err: any) => MaybePromiseLike<TOutput>,
   finallyFactory?: () => MaybePromiseLike<void>,
 ): MaybePromiseLike<TOutput> {
-  let result$ = fakePromise().then(inputFactory).then(outputSuccessFactory, outputErrorFactory);
-
   if (finallyFactory) {
-    result$ = result$.finally(finallyFactory);
+    return unfakePromise(
+      fakePromise()
+        .then(inputFactory)
+        .then(outputSuccessFactory, outputErrorFactory)
+        .finally(finallyFactory),
+    );
   }
-
-  return unfakePromise(result$);
+  // Faster impl without finallyFactory
+  function _handleMaybePromise() {
+    const input$ = inputFactory();
+    if (isFakePromise<TInput>(input$)) {
+      return outputSuccessFactory(input$.__fakePromiseValue);
+    }
+    if (isFakeRejectPromise(input$)) {
+      throw input$.__fakeRejectError;
+    }
+    if (isPromise(input$)) {
+      return input$.then(outputSuccessFactory, outputErrorFactory);
+    }
+    return outputSuccessFactory(input$);
+  }
+  if (!outputErrorFactory) {
+    return _handleMaybePromise();
+  }
+  try {
+    return _handleMaybePromise();
+  } catch (err) {
+    return outputErrorFactory(err);
+  }
 }
 
 export function fakePromise<T>(value: MaybePromise<T>): Promise<T>;

--- a/packages/promise-helpers/src/index.ts
+++ b/packages/promise-helpers/src/index.ts
@@ -33,10 +33,12 @@ export function handleMaybePromise<TInput, TOutput>(
   finallyFactory?: () => MaybePromiseLike<void>,
 ): MaybePromiseLike<TOutput> {
   let result$ = fakePromise().then(inputFactory).then(outputSuccessFactory, outputErrorFactory);
+
   if (finallyFactory) {
     result$ = result$.finally(finallyFactory);
   }
-  return result$;
+
+  return unfakePromise(result$);
 }
 
 export function fakePromise<T>(value: MaybePromise<T>): Promise<T>;

--- a/packages/promise-helpers/tests/handleMaybePromise.spec.ts
+++ b/packages/promise-helpers/tests/handleMaybePromise.spec.ts
@@ -64,42 +64,45 @@ describe('promise-helpers', () => {
         },
       );
 
-      it.each(cases)('when fake value is falsy', ({ input, output }) => {
-        expect(
-          handleMaybePromise(
-            () => (input === 'fake' ? fakePromise(undefined) : undefined),
-            res => (output === 'fake' ? fakePromise(undefined) : res),
-          ),
-        ).toBe(undefined);
+      it.each(cases)(
+        'when fake value is falsy; input: $input output: $output',
+        ({ input, output }) => {
+          expect(
+            handleMaybePromise(
+              () => (input === 'fake' ? fakePromise(undefined) : undefined),
+              res => (output === 'fake' ? fakePromise(undefined) : res),
+            ),
+          ).toBe(undefined);
 
-        expect(
-          handleMaybePromise(
-            () => (input === 'fake' ? fakePromise(null) : null),
-            res => (output === 'fake' ? fakePromise(null) : res),
-          ),
-        ).toBe(null);
+          expect(
+            handleMaybePromise(
+              () => (input === 'fake' ? fakePromise(null) : null),
+              res => (output === 'fake' ? fakePromise(null) : res),
+            ),
+          ).toBe(null);
 
-        expect(
-          handleMaybePromise(
-            () => (input === 'fake' ? fakePromise('') : ''),
-            res => (output === 'fake' ? fakePromise('') : res),
-          ),
-        ).toBe('');
+          expect(
+            handleMaybePromise(
+              () => (input === 'fake' ? fakePromise('') : ''),
+              res => (output === 'fake' ? fakePromise('') : res),
+            ),
+          ).toBe('');
 
-        expect(
-          handleMaybePromise(
-            () => (input === 'fake' ? fakePromise(false) : false),
-            res => (output === 'fake' ? fakePromise(false) : res),
-          ),
-        ).toBe(false);
+          expect(
+            handleMaybePromise(
+              () => (input === 'fake' ? fakePromise(false) : false),
+              res => (output === 'fake' ? fakePromise(false) : res),
+            ),
+          ).toBe(false);
 
-        expect(
-          handleMaybePromise(
-            () => (input === 'fake' ? fakePromise(0) : 0),
-            res => (output === 'fake' ? fakePromise(0) : res),
-          ),
-        ).toBe(0);
-      });
+          expect(
+            handleMaybePromise(
+              () => (input === 'fake' ? fakePromise(0) : 0),
+              res => (output === 'fake' ? fakePromise(0) : res),
+            ),
+          ).toBe(0);
+        },
+      );
     });
     describe('finally', () => {
       describe('with promises', () => {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,14 +41,16 @@
     "tslib": "^2.6.3"
   },
   "devDependencies": {
-    "@hapi/hapi": "^21.3.12",
+    "@hapi/hapi": "21.4.0",
+    "@types/compression": "1.7.5",
     "@types/express": "5.0.1",
-    "@types/koa": "^2.15.0",
-    "@types/node": "22.15.17",
+    "@types/koa": "2.15.0",
+"@types/node": "22.15.17",
+    "compression": "1.8.0",
     "express": "5.1.0",
     "fastify": "5.3.2",
-    "form-data": "^4.0.2",
-    "koa": "^3.0.0",
+    "form-data": "4.0.2",
+    "koa": "3.0.0",
     "react": "19.1.0",
     "react-dom": "19.1.0"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,7 +45,7 @@
     "@types/compression": "1.7.5",
     "@types/express": "5.0.1",
     "@types/koa": "2.15.0",
-"@types/node": "22.15.17",
+    "@types/node": "22.15.17",
     "compression": "1.8.0",
     "express": "5.1.0",
     "fastify": "5.3.2",

--- a/packages/server/src/createServerAdapter.ts
+++ b/packages/server/src/createServerAdapter.ts
@@ -30,7 +30,6 @@ import {
   isServerResponse,
   iterateAsyncVoid,
   NodeRequest,
-  nodeRequestResponseMap,
   NodeResponse,
   normalizeNodeRequest,
   sendNodeResponse,
@@ -278,8 +277,13 @@ function createServerAdapter<
   ) {
     const nodeResponse: NodeResponse =
       (nodeResponseOrContainer as any).raw || nodeResponseOrContainer;
-    nodeRequestResponseMap.set(nodeRequest, nodeResponse);
-    return handleNodeRequest(nodeRequest, ...ctx);
+    const serverContext = ctx.length > 1 ? completeAssign(...ctx) : ctx[0] || {};
+    // Ensure `waitUntil` is available in the server context
+    if (!serverContext.waitUntil) {
+      serverContext.waitUntil = waitUntil;
+    }
+    const request = normalizeNodeRequest(nodeRequest, fetchAPI, nodeResponse);
+    return handleRequest(request, serverContext);
   }
 
   function requestListener(

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -91,9 +91,11 @@ function isRequestBody(body: any): body is BodyInit {
   return false;
 }
 
-export const nodeRequestResponseMap = new WeakMap<NodeRequest, NodeResponse>();
-
-export function normalizeNodeRequest(nodeRequest: NodeRequest, fetchAPI: FetchAPI): Request {
+export function normalizeNodeRequest(
+  nodeRequest: NodeRequest,
+  fetchAPI: FetchAPI,
+  nodeResponse?: NodeResponse,
+): Request {
   const rawRequest = nodeRequest.raw || nodeRequest.req || nodeRequest;
   let fullUrl = buildFullUrl(rawRequest);
   if (nodeRequest.query) {
@@ -104,8 +106,6 @@ export function normalizeNodeRequest(nodeRequest: NodeRequest, fetchAPI: FetchAP
     fullUrl = url.toString();
   }
 
-  const nodeResponse = nodeRequestResponseMap.get(nodeRequest);
-  nodeRequestResponseMap.delete(nodeRequest);
   let normalizedHeaders: Record<string, string> = nodeRequest.headers;
   if (nodeRequest.headers?.[':method']) {
     normalizedHeaders = {};

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -355,7 +355,8 @@ export function sendNodeResponse(
     fetchResponse._buffer;
   if (bufOfRes) {
     // @ts-expect-error http and http2 writes are actually compatible
-    serverResponse.write(bufOfRes, () => endResponse(serverResponse));
+    serverResponse.write(bufOfRes);
+    endResponse(serverResponse);
     return;
   }
 

--- a/packages/server/test/reproductions.spec.ts
+++ b/packages/server/test/reproductions.spec.ts
@@ -81,41 +81,47 @@ if (!globalThis.Bun && !globalThis.Deno) {
   });
 }
 
-it('express + compression library', async () => {
-  const app = express();
+const bodies = [
+  'hello world', // 11 bytes
+  'hello world'.repeat(1024 * 1024), // 1MB
+  'hello world'.repeat(1024 * 1024 * 5), // 5MB
+];
 
-  app.use(compression());
+for (const largeBody of bodies) {
+  it(`express + compression (${largeBody.length} bytes)`, async () => {
+    const app = express();
 
-  const echoAdapter = createServerAdapter(req =>
-    req.json().then(body =>
-      Response.json({
-        body,
-        url: req.url,
-      }),
-    ),
-  );
+    app.use(compression());
 
-  app.use('/my-path', echoAdapter);
+    const echoAdapter = createServerAdapter(req =>
+      req.json().then(body =>
+        Response.json({
+          body,
+          url: req.url,
+        }),
+      ),
+    );
 
-  server = await new Promise<Server>((resolve, reject) => {
-    const server = app.listen(0, err => (err ? reject(err) : resolve(server)));
+    app.use('/my-path', echoAdapter);
+
+    server = await new Promise<Server>((resolve, reject) => {
+      const server = app.listen(0, err => (err ? reject(err) : resolve(server)));
+    });
+
+    const port = (server.address() as AddressInfo).port;
+
+    const response = await fetch(`http://localhost:${port}/my-path`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ largeBody }),
+    });
+
+    const bodyJson = await response.json();
+    expect(bodyJson).toEqual({
+      body: { largeBody },
+      url: `http://localhost:${port}/my-path`,
+    });
   });
-
-  const port = (server.address() as AddressInfo).port;
-
-  const largeBody = 'a'.repeat(1024 * 1024); // 1MB
-
-  const response = await fetch(`http://localhost:${port}/my-path`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ largeBody }),
-  });
-
-  const bodyJson = await response.json();
-  expect(bodyJson).toEqual({
-    body: { largeBody },
-    url: `http://localhost:${port}/my-path`,
-  });
-});
+}

--- a/packages/server/test/reproductions.spec.ts
+++ b/packages/server/test/reproductions.spec.ts
@@ -1,5 +1,6 @@
 import { createServer, Server } from 'node:http';
 import { AddressInfo } from 'node:net';
+import compression from 'compression';
 import express from 'express';
 import { afterEach, expect, it } from '@jest/globals';
 import { fetch } from '@whatwg-node/fetch';
@@ -79,3 +80,42 @@ if (!globalThis.Bun && !globalThis.Deno) {
     expect(await req!.text()).toEqual('hello world');
   });
 }
+
+it.only('express + compression library', async () => {
+  const app = express();
+
+  app.use(compression());
+
+  const echoAdapter = createServerAdapter(req =>
+    req.json().then(body =>
+      Response.json({
+        body,
+        url: req.url,
+      }),
+    ),
+  );
+
+  app.use('/my-path', echoAdapter);
+
+  server = await new Promise<Server>((resolve, reject) => {
+    const server = app.listen(0, err => (err ? reject(err) : resolve(server)));
+  });
+
+  const port = (server.address() as AddressInfo).port;
+
+  const largeBody = 'a'.repeat(1024 * 1024); // 1MB
+
+  const response = await fetch(`http://localhost:${port}/my-path`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ largeBody }),
+  });
+
+  const bodyJson = await response.json();
+  expect(bodyJson).toEqual({
+    body: { largeBody },
+    url: `http://localhost:${port}/my-path`,
+  });
+});

--- a/packages/server/test/reproductions.spec.ts
+++ b/packages/server/test/reproductions.spec.ts
@@ -81,7 +81,7 @@ if (!globalThis.Bun && !globalThis.Deno) {
   });
 }
 
-it.only('express + compression library', async () => {
+it('express + compression library', async () => {
   const app = express();
 
   app.use(compression());

--- a/packages/server/test/test-server.ts
+++ b/packages/server/test/test-server.ts
@@ -209,9 +209,8 @@ if (!globalThis.Deno) {
 
     fastifyApp.addContentTypeParser(/(.*)/, {}, (_req, _payload, done) => done(null));
 
-    let url = await fastifyApp.listen({ port: 0, host: '::1' });
-    url = url.replace('127.0.0.1', 'localhost');
-    url = url.replace('[::1]', 'localhost');
+    await fastifyApp.listen({ port: 0, host: '::' });
+    const url = `http://localhost:${(fastifyApp.server.address() as AddressInfo).port}`;
     return {
       name: 'fastify',
       url,

--- a/test.mjs
+++ b/test.mjs
@@ -1,0 +1,8 @@
+import { createServer } from 'node:http';
+import { Response } from '@whatwg-node/fetch';
+import { createServerAdapter } from '@whatwg-node/server';
+
+createServer(createServerAdapter(() => Response.json({ hello: 'world' }))).listen(3000, () => {
+  console.log('Server is running at http://localhost:3000');
+  console.log('Press Ctrl+C to stop the server.');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1608,7 +1608,7 @@
   resolved "https://registry.yarnpkg.com/@hapi/file/-/file-3.0.0.tgz#f1fd824493ac89a6fceaf89c824afc5ae2121c09"
   integrity sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q==
 
-"@hapi/hapi@^21.3.12":
+"@hapi/hapi@21.4.0":
   version "21.4.0"
   resolved "https://registry.yarnpkg.com/@hapi/hapi/-/hapi-21.4.0.tgz#6f1493ffd6d83ef2d06a95b6e855f554545e3703"
   integrity sha512-kqiRWbYYLSSt2rYbxyNj8svPsXP715p4W/K3OXpXeiiVLNSdBX4f+zfmC+dY6eyb6rqTqTAbx6x8b5HpJTkviQ==
@@ -3136,6 +3136,13 @@
     "@types/node" "*"
     "@types/responselike" "^1.0.0"
 
+"@types/compression@1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@types/compression/-/compression-1.7.5.tgz#0f80efef6eb031be57b12221c4ba6bc3577808f7"
+  integrity sha512-AAQvK5pxMpaT+nDvhHrsBhLSYG5yQdtkaJE1WYieSNY2mVFKAgmU4ks65rkZD5oqnGCFLyQpUr1CqI4DmUMyDg==
+  dependencies:
+    "@types/express" "*"
+
 "@types/connect@*":
   version "3.4.38"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
@@ -3267,7 +3274,7 @@
   dependencies:
     "@types/koa" "*"
 
-"@types/koa@*", "@types/koa@^2.15.0":
+"@types/koa@*", "@types/koa@2.15.0":
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.15.0.tgz#eca43d76f527c803b491731f95df575636e7b6f2"
   integrity sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==
@@ -4443,6 +4450,26 @@ common-ancestor-path@^1.0.1:
   resolved "https://registry.yarnpkg.com/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz#4f7d2d1394d91b7abdf51871c62f71eadb0182a7"
   integrity sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==
 
+compressible@~2.0.18:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
+  integrity sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==
+  dependencies:
+    mime-db ">= 1.43.0 < 2"
+
+compression@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.8.0.tgz#09420efc96e11a0f44f3a558de59e321364180f7"
+  integrity sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==
+  dependencies:
+    bytes "3.1.2"
+    compressible "~2.0.18"
+    debug "2.6.9"
+    negotiator "~0.6.4"
+    on-headers "~1.0.2"
+    safe-buffer "5.2.1"
+    vary "~1.1.2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4598,6 +4625,13 @@ dataloader@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
   integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
+
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 debug@4, debug@4.4.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0:
   version "4.4.0"
@@ -5701,7 +5735,7 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-form-data@^4.0.0, form-data@^4.0.2:
+form-data@4.0.2, form-data@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.2.tgz#35cabbdd30c3ce73deb2c42d3c8d3ed9ca51794c"
   integrity sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==
@@ -7270,7 +7304,7 @@ koa-compose@^4.1.0:
   resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-4.1.0.tgz#507306b9371901db41121c812e923d0d67d3e877"
   integrity sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==
 
-koa@^3.0.0:
+koa@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/koa/-/koa-3.0.0.tgz#42b74a8404bbeab1cfc40b2431f488112f5a4d7f"
   integrity sha512-Usyqf1o+XN618R3Jzq4S4YWbKsRtPcGpgyHXD4APdGYQQyqQ59X+Oyc7fXHS2429stzLsBiDjj6zqqYe8kknfw==
@@ -7574,7 +7608,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-db@^1.52.0, mime-db@^1.54.0:
+"mime-db@>= 1.43.0 < 2", mime-db@^1.52.0, mime-db@^1.54.0:
   version "1.54.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
@@ -7757,6 +7791,11 @@ mri@^1.2.0:
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
 ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -7774,7 +7813,6 @@ mvdan-sh@^0.10.1:
 
 "nan@github:JCMais/nan#fix/electron-failures":
   version "2.22.0"
-  uid "0ec2eca8b2fd7518affb3945d087e393ad839b7e"
   resolved "https://codeload.github.com/JCMais/nan/tar.gz/0ec2eca8b2fd7518affb3945d087e393ad839b7e"
 
 nanoid@^3.3.6:
@@ -7801,6 +7839,11 @@ negotiator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
+
+negotiator@~0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.4.tgz#777948e2452651c570b712dd01c23e262713fff7"
+  integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
 
 next@15.3.2:
   version "15.3.2"
@@ -8080,6 +8123,11 @@ on-finished@^2.3.0, on-finished@^2.4.1:
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -9957,7 +10005,6 @@ typescript@5.8.3:
 
 uWebSockets.js@uNetworking/uWebSockets.js#v20.51.0:
   version "20.51.0"
-  uid "6609a88ffa9a16ac5158046761356ce03250a0df"
   resolved "https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/6609a88ffa9a16ac5158046761356ce03250a0df"
 
 ufo@^1.5.4:
@@ -10156,7 +10203,7 @@ validate-npm-package-name@^5.0.0:
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz#a316573e9b49f3ccd90dbb6eb52b3f06c6d604e8"
   integrity sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==
 
-vary@^1, vary@^1.1.2:
+vary@^1, vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==


### PR DESCRIPTION
Some implementations like `compression` npm package do not implement `response.write(data, callback)` signature, but whatwg-node/server waits for it to finish the response stream.
Then it causes the response stream hangs when the compression package takes the stream over when the response data is larger than its threshold.

It is actually a bug in `compression` package;
[expressjs/compression#46](https://github.com/expressjs/compression/issues/46)
But since it is a common mistake, we prefer to workaround this on our end.

Now after calling `response.write`, it no longer uses callback but first it checks the result;

if it is `true`, it means stream is drained and we can call `response.end` immediately.
else if it is `false`, it means the stream is not drained yet, so we can wait for the `drain` event to call `response.end`.

This PR also does some improvements by unifying the "write and wait for drain logic".
And it removes the nodeRequestResponseMap stuff for performance gain.

Fixes https://github.com/graphql-hive/graphql-yoga/issues/3997