### PR TITLE
refactor(promise-helpers): reuse promise Symbol

### DIFF
--- a/.changeset/cruel-colts-show.md
+++ b/.changeset/cruel-colts-show.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/promise-helpers': patch
+---
+
+Reuse fake promise Symbol

--- a/packages/promise-helpers/src/index.ts
+++ b/packages/promise-helpers/src/index.ts
@@ -1,7 +1,7 @@
 export type MaybePromise<T> = Promise<T> | T;
 export type MaybePromiseLike<T> = PromiseLike<T> | T;
 
-const FAKE_PROMISE_SYMBOL_NAME = '@whatwg-node/promise-helpers/FakePromise';
+const kFakePromise = Symbol.for('@whatwg-node/promise-helpers/FakePromise');
 
 export function isPromise<T>(value: MaybePromise<T>): value is Promise<T>;
 export function isPromise<T>(value: MaybePromiseLike<T>): value is PromiseLike<T>;
@@ -89,7 +89,7 @@ export function fakePromise<T>(value: MaybePromiseLike<T>): Promise<T> {
     },
     [Symbol.toStringTag]: 'Promise',
     __fakePromiseValue: value,
-    [Symbol.for(FAKE_PROMISE_SYMBOL_NAME)]: 'resolved',
+    [kFakePromise]: 'resolved',
   } as Promise<T>;
 }
 
@@ -197,7 +197,7 @@ export function fakeRejectPromise<T>(error: unknown): Promise<T> {
     },
     __fakeRejectError: error,
     [Symbol.toStringTag]: 'Promise',
-    [Symbol.for(FAKE_PROMISE_SYMBOL_NAME)]: 'rejected',
+    [kFakePromise]: 'rejected',
   } as Promise<never>;
 }
 
@@ -315,11 +315,11 @@ function iteratorResult<T>(value: T): IteratorResult<T> {
 }
 
 function isFakePromise<T>(value: any): value is Promise<T> & { __fakePromiseValue: T } {
-  return (value as any)?.[Symbol.for(FAKE_PROMISE_SYMBOL_NAME)] === 'resolved';
+  return (value as any)?.[kFakePromise] === 'resolved';
 }
 
 function isFakeRejectPromise(value: any): value is Promise<never> & { __fakeRejectError: any } {
-  return (value as any)?.[Symbol.for(FAKE_PROMISE_SYMBOL_NAME)] === 'rejected';
+  return (value as any)?.[kFakePromise] === 'rejected';
 }
 
 export function promiseLikeFinally<T>(


### PR DESCRIPTION
## Description

Instead of asking the global namespace for it every time, store the reference and put access it faster each time it's used.

Comparing to the published server v0.10.5 with #2383 reverted. I reverted it because even though removing of the `WeakMap` improves performance, the other changes make it dunk. When I picked changes from #1505 (and ended with the same approach as #2383 without removing public API), it was 3-5% faster. 

Fastify benchmarks against `node:http`.
```
┌──────────────────────────┬─────────┬────────┬────────────┬──────────────┬───────────────┐
│                          │ Version │ Router │ Requests/s │ Latency (ms) │ Throughput/Mb │
├──────────────────────────┼─────────┼────────┼────────────┼──────────────┼───────────────┤
│ node-http                │ v24.0.1 │ ✗      │ 61911.2    │ 15.66        │ 11.04         │
├──────────────────────────┼─────────┼────────┼────────────┼──────────────┼───────────────┤
│ whatwg-node-server-local │ 0.10.5  │ ✗      │ 54320.0    │ 17.91        │ 9.69          │
├──────────────────────────┼─────────┼────────┼────────────┼──────────────┼───────────────┤
│ whatwg-node-server       │ 0.10.5  │ ✗      │ 52256.8    │ 18.62        │ 9.32          │
└──────────────────────────┴─────────┴────────┴────────────┴──────────────┴───────────────┘
```
many runs, actually:
```
┌──────────────────────────┬─────────┬────────┬────────────┬──────────────┬───────────────┐
│                          │ Version │ Router │ Requests/s │ Latency (ms) │ Throughput/Mb │
├──────────────────────────┼─────────┼────────┼────────────┼──────────────┼───────────────┤
│ node-http                │ v24.0.1 │ ✗      │ 62528.8    │ 15.48        │ 11.15         │
├──────────────────────────┼─────────┼────────┼────────────┼──────────────┼───────────────┤
│ whatwg-node-server-local │ 0.10.5  │ ✗      │ 54447.2    │ 17.86        │ 9.71          │
├──────────────────────────┼─────────┼────────┼────────────┼──────────────┼───────────────┤
│ whatwg-node-server       │ 0.10.5  │ ✗      │ 52801.6    │ 18.45        │ 9.42          │
└──────────────────────────┴─────────┴────────┴────────────┴──────────────┴───────────────┘
```
<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

n/a

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This change based on current master:

```
┌──────────────────────────┬─────────┬────────┬────────────┬──────────────┬───────────────┐
│                          │ Version │ Router │ Requests/s │ Latency (ms) │ Throughput/Mb │
├──────────────────────────┼─────────┼────────┼────────────┼──────────────┼───────────────┤
│ node-http                │ v24.0.1 │ ✗      │ 61268.0    │ 15.83        │ 10.93         │
├──────────────────────────┼─────────┼────────┼────────────┼──────────────┼───────────────┤
│ whatwg-node-server       │ 0.10.5  │ ✗      │ 51875.2    │ 18.78        │ 9.25          │
├──────────────────────────┼─────────┼────────┼────────────┼──────────────┼───────────────┤
│ whatwg-node-server-local │ 0.10.5  │ ✗      │ 49934.4    │ 19.52        │ 8.90          │
└──────────────────────────┴─────────┴────────┴────────────┴──────────────┴───────────────┘
```

Just master vs published `v0.10.5`:
```
┌──────────────────────────┬─────────┬────────┬────────────┬──────────────┬───────────────┐
│                          │ Version │ Router │ Requests/s │ Latency (ms) │ Throughput/Mb │
├──────────────────────────┼─────────┼────────┼────────────┼──────────────┼───────────────┤
│ node-http                │ v24.0.1 │ ✗      │ 63389.2    │ 15.27        │ 11.30         │
├──────────────────────────┼─────────┼────────┼────────────┼──────────────┼───────────────┤
│ whatwg-node-server       │ 0.10.5  │ ✗      │ 53907.2    │ 18.06        │ 9.61          │
├──────────────────────────┼─────────┼────────┼────────────┼──────────────┼───────────────┤
│ whatwg-node-server-local │ 0.10.5  │ ✗      │ 49610.4    │ 19.66        │ 8.85          │
└──────────────────────────┴─────────┴────────┴────────────┴──────────────┴───────────────┘
```