### PR TITLE
Performance optimizations

### DIFF
--- a/.changeset/curvy-seas-smoke.md
+++ b/.changeset/curvy-seas-smoke.md
@@ -1,5 +1,14 @@
 ---
+'@whatwg-node/fetch': patch
+'@whatwg-node/server': patch
 '@whatwg-node/node-fetch': patch
 ---
 
-Avoid creating a new AbortSignal which is expensive
+Performance optimizations for Node 24
+
+- Use `once` from `node:events` for Promise-based event handling whenever
+possible
+- Avoid creating `AbortController` and `AbortSignal` if not needed with `new Request` because it is expensive
+- Avoid creating a map for `Headers` and try to re-use the init object for `Headers` for performance with a single-line `writeHead`.
+- Avoid creating `Buffer` for `string` bodies for performance
+- Use `setHeaders` which accepts `Headers` since Node 18 if needed to forward `Headers` to Node

--- a/.changeset/curvy-seas-smoke.md
+++ b/.changeset/curvy-seas-smoke.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/node-fetch': patch
+---
+
+Avoid creating a new AbortSignal which is expensive

--- a/.changeset/curvy-seas-smoke.md
+++ b/.changeset/curvy-seas-smoke.md
@@ -4,10 +4,8 @@
 '@whatwg-node/node-fetch': patch
 ---
 
-Performance optimizations for Node 24
+Performance optimizations
 
-- Use `once` from `node:events` for Promise-based event handling whenever
-possible
 - Avoid creating `AbortController` and `AbortSignal` if not needed with `new Request` because it is expensive
 - Avoid creating a map for `Headers` and try to re-use the init object for `Headers` for performance with a single-line `writeHead`.
 - Avoid creating `Buffer` for `string` bodies for performance

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -90,8 +90,8 @@ export default [
           devDependencies: [
             '**/*.test.ts',
             '**/*.spec.ts',
-            'vitest.config.ts',
-            'vitest.projects.ts',
+            '**/vitest.config.ts',
+            '**/vitest.projects.ts',
           ],
         },
       ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -87,7 +87,12 @@ export default [
       'import/no-extraneous-dependencies': [
         'error',
         {
-          devDependencies: ['**/*.test.ts', '**/*.spec.ts'],
+          devDependencies: [
+            '**/*.test.ts',
+            '**/*.spec.ts',
+            'vitest.config.ts',
+            'vitest.projects.ts',
+          ],
         },
       ],
     },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "packageManager": "yarn@1.22.22",
   "scripts": {
+    "bench": "vitest bench --project bench",
     "build": "bob build",
     "ci:lint": "eslint . --output-file eslint_report.json --format json",
     "clean-dist": "rimraf \"dist\" && rimraf \".bob\"",
@@ -69,7 +70,9 @@
     "prettier": "3.5.3",
     "rimraf": "6.0.1",
     "ts-jest": "29.3.4",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "vite-tsconfig-paths": "5.1.4",
+    "vitest": "3.1.3"
   },
   "resolutions": {
     "@pulumi/pulumi": "3.170.0",

--- a/packages/node-fetch/src/Body.ts
+++ b/packages/node-fetch/src/Body.ts
@@ -45,20 +45,20 @@ export interface FormDataLimits {
 
 export interface PonyfillBodyOptions {
   formDataLimits?: FormDataLimits;
-  signal?: AbortSignal;
+  signal?: AbortSignal | undefined;
 }
 
 export class PonyfillBody<TJSON = any> implements Body {
   bodyUsed = false;
   contentType: string | null = null;
   contentLength: number | null = null;
-  signal?: AbortSignal | null = null;
+  _signal?: AbortSignal | null = null;
 
   constructor(
     private bodyInit: BodyPonyfillInit | null,
     private options: PonyfillBodyOptions = {},
   ) {
-    this.signal = options.signal || null;
+    this._signal = options.signal || null;
     const { bodyFactory, contentType, contentLength, bodyType, buffer } = processBodyInit(
       bodyInit,
       options?.signal,
@@ -265,8 +265,8 @@ export class PonyfillBody<TJSON = any> implements Body {
         defCharset: 'utf-8',
       });
 
-      if (this.signal) {
-        addAbortSignal(this.signal, bb);
+      if (this._signal) {
+        addAbortSignal(this._signal, bb);
       }
 
       let completed = false;

--- a/packages/node-fetch/src/Headers.ts
+++ b/packages/node-fetch/src/Headers.ts
@@ -151,11 +151,7 @@ export class PonyfillHeaders implements Headers {
       this._setCookies = [value];
       return;
     }
-    if (this._map) {
-      this._map.set(key, value);
-      return;
-    }
-    if (this.headersInit != null) {
+    if (!this._map && this.headersInit != null) {
       if (isArray(this.headersInit)) {
         const found = this.headersInit.find(([headerKey]) => headerKey.toLowerCase() === key);
         if (found) {

--- a/packages/node-fetch/src/Headers.ts
+++ b/packages/node-fetch/src/Headers.ts
@@ -159,8 +159,10 @@ export class PonyfillHeaders implements Headers {
         const found = this.headersInit.find(([headerKey]) => headerKey.toLowerCase() === key);
         if (found) {
           found[1] = value;
-          return;
+        } else {
+          this.headersInit.push([key, value]);
         }
+        return;
       } else if (isHeadersLike(this.headersInit)) {
         this.headersInit.set(key, value);
         return;

--- a/packages/node-fetch/src/Headers.ts
+++ b/packages/node-fetch/src/Headers.ts
@@ -1,5 +1,6 @@
 import { inspect } from 'node:util';
 import { PonyfillIteratorObject } from './IteratorObject.js';
+import { isArray } from './utils.js';
 
 export type PonyfillHeadersInit = [string, string][] | Record<string, string> | Headers;
 
@@ -31,7 +32,7 @@ export class PonyfillHeaders implements Headers {
       return null;
     }
 
-    if (Array.isArray(this.headersInit)) {
+    if (isArray(this.headersInit)) {
       const found = this.headersInit.filter(
         ([headerKey]) => headerKey.toLowerCase() === normalized,
       );
@@ -72,7 +73,7 @@ export class PonyfillHeaders implements Headers {
     if (!this._map) {
       this._setCookies = [];
       if (this.headersInit != null) {
-        if (Array.isArray(this.headersInit)) {
+        if (isArray(this.headersInit)) {
           this._map = new Map();
           for (const [key, value] of this.headersInit) {
             const normalizedKey = key.toLowerCase();
@@ -155,7 +156,7 @@ export class PonyfillHeaders implements Headers {
       return;
     }
     if (this.headersInit != null) {
-      if (Array.isArray(this.headersInit)) {
+      if (isArray(this.headersInit)) {
         const found = this.headersInit.find(([headerKey]) => headerKey.toLowerCase() === key);
         if (found) {
           found[1] = value;
@@ -189,7 +190,7 @@ export class PonyfillHeaders implements Headers {
     });
     if (!this._map) {
       if (this.headersInit) {
-        if (Array.isArray(this.headersInit)) {
+        if (isArray(this.headersInit)) {
           this.headersInit.forEach(([key, value]) => {
             callback(value, key, this);
           });
@@ -218,7 +219,7 @@ export class PonyfillHeaders implements Headers {
     }
     if (!this._map) {
       if (this.headersInit) {
-        if (Array.isArray(this.headersInit)) {
+        if (isArray(this.headersInit)) {
           yield* this.headersInit.map(([key]) => key)[Symbol.iterator]();
           return;
         }
@@ -243,7 +244,7 @@ export class PonyfillHeaders implements Headers {
     }
     if (!this._map) {
       if (this.headersInit) {
-        if (Array.isArray(this.headersInit)) {
+        if (isArray(this.headersInit)) {
           yield* this.headersInit.map(([, value]) => value)[Symbol.iterator]();
           return;
         }
@@ -268,7 +269,7 @@ export class PonyfillHeaders implements Headers {
     }
     if (!this._map) {
       if (this.headersInit) {
-        if (Array.isArray(this.headersInit)) {
+        if (isArray(this.headersInit)) {
           yield* this.headersInit;
           return;
         }

--- a/packages/node-fetch/src/Headers.ts
+++ b/packages/node-fetch/src/Headers.ts
@@ -150,6 +150,18 @@ export class PonyfillHeaders implements Headers {
       this._setCookies = [value];
       return;
     }
+    if (this._map) {
+      this._map.set(key, value);
+      return;
+    }
+    if (
+      this.headersInit != null &&
+      !isHeadersLike(this.headersInit) &&
+      !Array.isArray(this.headersInit)
+    ) {
+      this.headersInit[key] = value;
+      return;
+    }
     this.getMap().set(key, value);
   }
 

--- a/packages/node-fetch/src/Headers.ts
+++ b/packages/node-fetch/src/Headers.ts
@@ -154,13 +154,20 @@ export class PonyfillHeaders implements Headers {
       this._map.set(key, value);
       return;
     }
-    if (
-      this.headersInit != null &&
-      !isHeadersLike(this.headersInit) &&
-      !Array.isArray(this.headersInit)
-    ) {
-      this.headersInit[key] = value;
-      return;
+    if (this.headersInit != null) {
+      if (Array.isArray(this.headersInit)) {
+        const found = this.headersInit.find(([headerKey]) => headerKey.toLowerCase() === key);
+        if (found) {
+          found[1] = value;
+          return;
+        }
+      } else if (isHeadersLike(this.headersInit)) {
+        this.headersInit.set(key, value);
+        return;
+      } else {
+        this.headersInit[key] = value;
+        return;
+      }
     }
     this.getMap().set(key, value);
   }

--- a/packages/node-fetch/src/Headers.ts
+++ b/packages/node-fetch/src/Headers.ts
@@ -71,7 +71,7 @@ export class PonyfillHeaders implements Headers {
   // I could do a getter here, but I'm too lazy to type `getter`.
   private getMap() {
     if (!this._map) {
-      this._setCookies = [];
+      this._setCookies ||= [];
       if (this.headersInit != null) {
         if (isArray(this.headersInit)) {
           this._map = new Map();
@@ -139,7 +139,8 @@ export class PonyfillHeaders implements Headers {
   }
 
   has(name: string): boolean {
-    if (name === 'set-cookie') {
+    const key = name.toLowerCase();
+    if (key === 'set-cookie') {
       return !!this._setCookies?.length;
     }
     return !!this._get(name); // we might need to check if header exists and not just check if it's not nullable

--- a/packages/node-fetch/src/Headers.ts
+++ b/packages/node-fetch/src/Headers.ts
@@ -1,6 +1,5 @@
 import { inspect } from 'node:util';
 import { PonyfillIteratorObject } from './IteratorObject.js';
-import { isArray } from './utils.js';
 
 export type PonyfillHeadersInit = [string, string][] | Record<string, string> | Headers;
 
@@ -32,7 +31,7 @@ export class PonyfillHeaders implements Headers {
       return null;
     }
 
-    if (isArray(this.headersInit)) {
+    if (Array.isArray(this.headersInit)) {
       const found = this.headersInit.filter(
         ([headerKey]) => headerKey.toLowerCase() === normalized,
       );
@@ -73,7 +72,7 @@ export class PonyfillHeaders implements Headers {
     if (!this._map) {
       this._setCookies ||= [];
       if (this.headersInit != null) {
-        if (isArray(this.headersInit)) {
+        if (Array.isArray(this.headersInit)) {
           this._map = new Map();
           for (const [key, value] of this.headersInit) {
             const normalizedKey = key.toLowerCase();
@@ -153,7 +152,7 @@ export class PonyfillHeaders implements Headers {
       return;
     }
     if (!this._map && this.headersInit != null) {
-      if (isArray(this.headersInit)) {
+      if (Array.isArray(this.headersInit)) {
         const found = this.headersInit.find(([headerKey]) => headerKey.toLowerCase() === key);
         if (found) {
           found[1] = value;
@@ -187,7 +186,7 @@ export class PonyfillHeaders implements Headers {
     });
     if (!this._map) {
       if (this.headersInit) {
-        if (isArray(this.headersInit)) {
+        if (Array.isArray(this.headersInit)) {
           this.headersInit.forEach(([key, value]) => {
             callback(value, key, this);
           });
@@ -216,7 +215,7 @@ export class PonyfillHeaders implements Headers {
     }
     if (!this._map) {
       if (this.headersInit) {
-        if (isArray(this.headersInit)) {
+        if (Array.isArray(this.headersInit)) {
           yield* this.headersInit.map(([key]) => key)[Symbol.iterator]();
           return;
         }
@@ -241,7 +240,7 @@ export class PonyfillHeaders implements Headers {
     }
     if (!this._map) {
       if (this.headersInit) {
-        if (isArray(this.headersInit)) {
+        if (Array.isArray(this.headersInit)) {
           yield* this.headersInit.map(([, value]) => value)[Symbol.iterator]();
           return;
         }
@@ -266,7 +265,7 @@ export class PonyfillHeaders implements Headers {
     }
     if (!this._map) {
       if (this.headersInit) {
-        if (isArray(this.headersInit)) {
+        if (Array.isArray(this.headersInit)) {
           yield* this.headersInit;
           return;
         }

--- a/packages/node-fetch/src/Request.ts
+++ b/packages/node-fetch/src/Request.ts
@@ -73,7 +73,6 @@ export class PonyfillRequest<TJSON = any> extends PonyfillBody<TJSON> implements
     this.redirect = requestInit?.redirect || 'follow';
     this.referrer = requestInit?.referrer || 'about:client';
     this.referrerPolicy = requestInit?.referrerPolicy || 'no-referrer';
-    this.signal = requestInit?.signal || new AbortController().signal;
     this.headersSerializer = requestInit?.headersSerializer;
     this.duplex = requestInit?.duplex || 'half';
 
@@ -110,6 +109,12 @@ export class PonyfillRequest<TJSON = any> extends PonyfillBody<TJSON> implements
   referrer: string;
   referrerPolicy: ReferrerPolicy;
   _url: string | undefined;
+
+  get signal(): AbortSignal {
+    this._signal ||= new AbortController().signal;
+    return this._signal;
+  }
+
   get url(): string {
     if (this._url == null) {
       if (this._parsedUrl) {
@@ -136,8 +141,6 @@ export class PonyfillRequest<TJSON = any> extends PonyfillBody<TJSON> implements
   duplex: 'half' | 'full';
 
   agent: HTTPAgent | HTTPSAgent | false | undefined;
-
-  signal: AbortSignal;
 
   clone(): PonyfillRequest<TJSON> {
     return this;

--- a/packages/node-fetch/src/Response.ts
+++ b/packages/node-fetch/src/Response.ts
@@ -26,7 +26,6 @@ export class PonyfillResponse<TJSON = any> extends PonyfillBody<TJSON> implement
     this.url = init?.url || '';
     this.redirected = init?.redirected || false;
     this.type = init?.type || 'default';
-    this.signal = init?.signal || null;
 
     this.handleContentLengthHeader();
   }

--- a/packages/node-fetch/src/Response.ts
+++ b/packages/node-fetch/src/Response.ts
@@ -65,30 +65,55 @@ export class PonyfillResponse<TJSON = any> extends PonyfillBody<TJSON> implement
   }
 
   static json<T = any>(data: T, init?: ResponsePonyfilInit) {
+    const bodyInit = JSON.stringify(data);
+    const contentLength = Buffer.byteLength(bodyInit);
     if (!init) {
       init = {
         headers: {
           'content-type': JSON_CONTENT_TYPE,
+          'content-length': contentLength.toString(),
         },
       };
     } else if (!init.headers) {
       init.headers = {
         'content-type': JSON_CONTENT_TYPE,
+        'content-length': contentLength.toString(),
       };
     } else if (isHeadersLike(init.headers)) {
       if (!init.headers.has('content-type')) {
         init.headers.set('content-type', JSON_CONTENT_TYPE);
       }
+      if (!init.headers.has('content-length')) {
+        init.headers.set('content-length', contentLength.toString());
+      }
     } else if (Array.isArray(init.headers)) {
-      if (!init.headers.some(([key]) => key.toLowerCase() === 'content-type')) {
+      let contentTypeExists = false;
+      let contentLengthExists = false;
+      for (const [key] of init.headers) {
+        if (contentLengthExists && contentTypeExists) {
+          break;
+        }
+        if (!contentTypeExists && key.toLowerCase() === 'content-type') {
+          contentTypeExists = true;
+        } else if (!contentLengthExists && key.toLowerCase() === 'content-length') {
+          contentLengthExists = true;
+        }
+      }
+      if (!contentTypeExists) {
         init.headers.push(['content-type', JSON_CONTENT_TYPE]);
+      }
+      if (!contentLengthExists) {
+        init.headers.push(['content-length', contentLength.toString()]);
       }
     } else if (typeof init.headers === 'object') {
       if (init.headers?.['content-type'] == null) {
         init.headers['content-type'] = JSON_CONTENT_TYPE;
       }
+      if (init.headers?.['content-length'] == null) {
+        init.headers['content-length'] = contentLength.toString();
+      }
     }
-    return new PonyfillResponse<T>(JSON.stringify(data), init);
+    return new PonyfillResponse<T>(bodyInit, init);
   }
 
   [Symbol.toStringTag] = 'Response';

--- a/packages/node-fetch/src/Response.ts
+++ b/packages/node-fetch/src/Response.ts
@@ -1,6 +1,7 @@
 import { STATUS_CODES } from 'node:http';
 import { BodyPonyfillInit, PonyfillBody, PonyfillBodyOptions } from './Body.js';
 import { isHeadersLike, PonyfillHeaders, PonyfillHeadersInit } from './Headers.js';
+import { isArray } from './utils.js';
 
 export type ResponsePonyfilInit = PonyfillBodyOptions &
   Omit<ResponseInit, 'headers'> & {
@@ -79,7 +80,7 @@ export class PonyfillResponse<TJSON = any> extends PonyfillBody<TJSON> implement
       if (!init.headers.has('content-type')) {
         init.headers.set('content-type', JSON_CONTENT_TYPE);
       }
-    } else if (Array.isArray(init.headers)) {
+    } else if (isArray(init.headers)) {
       if (!init.headers.some(([key]) => key.toLowerCase() === 'content-type')) {
         init.headers.push(['content-type', JSON_CONTENT_TYPE]);
       }

--- a/packages/node-fetch/src/Response.ts
+++ b/packages/node-fetch/src/Response.ts
@@ -64,13 +64,29 @@ export class PonyfillResponse<TJSON = any> extends PonyfillBody<TJSON> implement
     });
   }
 
-  static json<T = any>(data: T, init: ResponsePonyfilInit = {}) {
-    init.headers =
-      init?.headers && isHeadersLike(init.headers)
-        ? init.headers
-        : new PonyfillHeaders(init?.headers);
-    if (!init.headers.has('content-type')) {
-      init.headers.set('content-type', JSON_CONTENT_TYPE);
+  static json<T = any>(data: T, init?: ResponsePonyfilInit) {
+    if (!init) {
+      init = {
+        headers: {
+          'content-type': JSON_CONTENT_TYPE,
+        },
+      };
+    } else if (!init.headers) {
+      init.headers = {
+        'content-type': JSON_CONTENT_TYPE,
+      };
+    } else if (isHeadersLike(init.headers)) {
+      if (!init.headers.has('content-type')) {
+        init.headers.set('content-type', JSON_CONTENT_TYPE);
+      }
+    } else if (Array.isArray(init.headers)) {
+      if (!init.headers.some(([key]) => key.toLowerCase() === 'content-type')) {
+        init.headers.push(['content-type', JSON_CONTENT_TYPE]);
+      }
+    } else if (typeof init.headers === 'object') {
+      if (init.headers?.['content-type'] == null) {
+        init.headers['content-type'] = JSON_CONTENT_TYPE;
+      }
     }
     return new PonyfillResponse<T>(JSON.stringify(data), init);
   }

--- a/packages/node-fetch/src/Response.ts
+++ b/packages/node-fetch/src/Response.ts
@@ -66,25 +66,24 @@ export class PonyfillResponse<TJSON = any> extends PonyfillBody<TJSON> implement
 
   static json<T = any>(data: T, init?: ResponsePonyfilInit) {
     const bodyInit = JSON.stringify(data);
-    const contentLength = Buffer.byteLength(bodyInit);
     if (!init) {
       init = {
         headers: {
           'content-type': JSON_CONTENT_TYPE,
-          'content-length': contentLength.toString(),
+          'content-length': Buffer.byteLength(bodyInit).toString(),
         },
       };
     } else if (!init.headers) {
       init.headers = {
         'content-type': JSON_CONTENT_TYPE,
-        'content-length': contentLength.toString(),
+        'content-length': Buffer.byteLength(bodyInit).toString(),
       };
     } else if (isHeadersLike(init.headers)) {
       if (!init.headers.has('content-type')) {
         init.headers.set('content-type', JSON_CONTENT_TYPE);
       }
       if (!init.headers.has('content-length')) {
-        init.headers.set('content-length', contentLength.toString());
+        init.headers.set('content-length', Buffer.byteLength(bodyInit).toString());
       }
     } else if (Array.isArray(init.headers)) {
       let contentTypeExists = false;
@@ -103,14 +102,14 @@ export class PonyfillResponse<TJSON = any> extends PonyfillBody<TJSON> implement
         init.headers.push(['content-type', JSON_CONTENT_TYPE]);
       }
       if (!contentLengthExists) {
-        init.headers.push(['content-length', contentLength.toString()]);
+        init.headers.push(['content-length', Buffer.byteLength(bodyInit).toString()]);
       }
     } else if (typeof init.headers === 'object') {
       if (init.headers?.['content-type'] == null) {
         init.headers['content-type'] = JSON_CONTENT_TYPE;
       }
       if (init.headers?.['content-length'] == null) {
-        init.headers['content-length'] = contentLength.toString();
+        init.headers['content-length'] = Buffer.byteLength(bodyInit).toString();
       }
     }
     return new PonyfillResponse<T>(bodyInit, init);

--- a/packages/node-fetch/src/Response.ts
+++ b/packages/node-fetch/src/Response.ts
@@ -1,7 +1,6 @@
 import { STATUS_CODES } from 'node:http';
 import { BodyPonyfillInit, PonyfillBody, PonyfillBodyOptions } from './Body.js';
 import { isHeadersLike, PonyfillHeaders, PonyfillHeadersInit } from './Headers.js';
-import { isArray } from './utils.js';
 
 export type ResponsePonyfilInit = PonyfillBodyOptions &
   Omit<ResponseInit, 'headers'> & {
@@ -80,7 +79,7 @@ export class PonyfillResponse<TJSON = any> extends PonyfillBody<TJSON> implement
       if (!init.headers.has('content-type')) {
         init.headers.set('content-type', JSON_CONTENT_TYPE);
       }
-    } else if (isArray(init.headers)) {
+    } else if (Array.isArray(init.headers)) {
       if (!init.headers.some(([key]) => key.toLowerCase() === 'content-type')) {
         init.headers.push(['content-type', JSON_CONTENT_TYPE]);
       }

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -90,7 +90,3 @@ export function safeWrite(chunk: any, stream: Writable, signal?: AbortSignal | u
     }) as unknown as Promise<any>;
   }
 }
-
-export function isArray<T>(value: any): value is T[] {
-  return value?.splice != null;
-}

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -92,5 +92,5 @@ export function safeWrite(chunk: any, stream: Writable, signal?: AbortSignal | u
 }
 
 export function isArray<T>(value: any): value is T[] {
-  return value?.splice;
+  return value?.splice != null;
 }

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -92,5 +92,5 @@ export function safeWrite(chunk: any, stream: Writable, signal?: AbortSignal | u
 }
 
 export function isArray<T>(value: any): value is T[] {
-  return value?.length != null && value?.map && value?.slice && value?.splice;
+  return value?.splice;
 }

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -11,6 +11,11 @@ export function getHeadersObj(headers: Headers): Record<string, string> {
   if (headers == null || !isHeadersInstance(headers)) {
     return headers as any;
   }
+  // @ts-expect-error - `headersInit` is not a public property
+  if (headers.headersInit && !headers._map && !isHeadersInstance(headers.headersInit)) {
+    // @ts-expect-error - `headersInit` is not a public property
+    return headers.headersInit;
+  }
   return Object.fromEntries(headers.entries());
 }
 
@@ -87,5 +92,5 @@ export function safeWrite(chunk: any, stream: Writable, signal?: AbortSignal | u
 }
 
 export function isArray<T>(value: any): value is T[] {
-  return value?.length && value?.map && value?.slice && value?.splice;
+  return value?.length != null && value?.map && value?.slice && value?.splice;
 }

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -85,3 +85,7 @@ export function safeWrite(chunk: any, stream: Writable, signal?: AbortSignal | u
     }) as unknown as Promise<any>;
   }
 }
+
+export function isArray<T>(value: any): value is T[] {
+  return value?.length && value?.map && value?.slice && value?.splice;
+}

--- a/packages/server/src/createServerAdapter.ts
+++ b/packages/server/src/createServerAdapter.ts
@@ -337,10 +337,9 @@ function createServerAdapter<
         ? completeAssign(defaultServerContext, ...ctx)
         : defaultServerContext;
 
-    const controller =
-      fetchAPI.Request === globalThis.Request
-        ? new AbortController()
-        : new CustomAbortControllerSignal();
+    const controller = useCustomAbortCtrl
+      ? new CustomAbortControllerSignal()
+      : new AbortController();
     const originalResEnd = res.end.bind(res);
     let resEnded = false;
     res.end = function (data: any) {

--- a/packages/server/src/createServerAdapter.ts
+++ b/packages/server/src/createServerAdapter.ts
@@ -103,12 +103,14 @@ function createServerAdapter<
 ): ServerAdapter<TServerContext, TBaseObject> {
   const useSingleWriteHead =
     options?.__useSingleWriteHead == null ? true : options.__useSingleWriteHead;
-  const useCustomAbortCtrl =
-    options?.__useCustomAbortCtrl == null ? true : options.__useCustomAbortCtrl;
   const fetchAPI = {
     ...DefaultFetchAPI,
     ...options?.fetchAPI,
   };
+  const useCustomAbortCtrl =
+    options?.__useCustomAbortCtrl == null
+      ? fetchAPI.Request !== globalThis.Request
+      : options.__useCustomAbortCtrl;
   const givenHandleRequest =
     typeof serverAdapterBaseObject === 'function'
       ? serverAdapterBaseObject

--- a/packages/server/src/createServerAdapter.ts
+++ b/packages/server/src/createServerAdapter.ts
@@ -19,6 +19,7 @@ import {
 } from './types.js';
 import {
   completeAssign,
+  CustomAbortControllerSignal,
   ensureDisposableStackRegisteredForTerminateEvents,
   handleAbortSignalAndPromiseResponse,
   handleErrorFromRequestHandler,
@@ -326,7 +327,10 @@ function createServerAdapter<
         ? completeAssign(defaultServerContext, ...ctx)
         : defaultServerContext;
 
-    const controller = new AbortController();
+    const controller =
+      fetchAPI.Request === globalThis.Request
+        ? new AbortController()
+        : new CustomAbortControllerSignal();
     const originalResEnd = res.end.bind(res);
     let resEnded = false;
     res.end = function (data: any) {

--- a/packages/server/src/plugins/useCors.ts
+++ b/packages/server/src/plugins/useCors.ts
@@ -1,4 +1,5 @@
 import { handleMaybePromise, MaybePromise } from '@whatwg-node/promise-helpers';
+import { isArray } from '../utils.js';
 import type { ServerAdapterPlugin } from './types.js';
 
 export type CORSOptions =
@@ -46,7 +47,7 @@ export function getCORSHeadersByRequestAndOptions(
   } else if (typeof corsOptions.origin === 'string') {
     // If there is one specific origin is specified, use it directly
     headers['Access-Control-Allow-Origin'] = corsOptions.origin;
-  } else if (Array.isArray(corsOptions.origin)) {
+  } else if (isArray(corsOptions.origin)) {
     // If there is only one origin defined in the array, consider it as a single one
     if (corsOptions.origin.length === 1) {
       headers['Access-Control-Allow-Origin'] = corsOptions.origin[0];

--- a/packages/server/src/plugins/useCors.ts
+++ b/packages/server/src/plugins/useCors.ts
@@ -1,5 +1,4 @@
 import { handleMaybePromise, MaybePromise } from '@whatwg-node/promise-helpers';
-import { isArray } from '../utils.js';
 import type { ServerAdapterPlugin } from './types.js';
 
 export type CORSOptions =
@@ -47,7 +46,7 @@ export function getCORSHeadersByRequestAndOptions(
   } else if (typeof corsOptions.origin === 'string') {
     // If there is one specific origin is specified, use it directly
     headers['Access-Control-Allow-Origin'] = corsOptions.origin;
-  } else if (isArray(corsOptions.origin)) {
+  } else if (Array.isArray(corsOptions.origin)) {
     // If there is only one origin defined in the array, consider it as a single one
     if (corsOptions.origin.length === 1) {
       headers['Access-Control-Allow-Origin'] = corsOptions.origin[0];

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -116,14 +116,9 @@ export function normalizeNodeRequest(
       }
     }
   }
-  let controller: AbortController;
-  if (__useCustomAbortCtrl) {
-    controller = new CustomAbortControllerSignal();
-  } else if (fetchAPI.Request === globalThis.Request) {
-    controller = new AbortController();
-  } else {
-    controller = new CustomAbortControllerSignal();
-  }
+  const controller = __useCustomAbortCtrl
+    ? new CustomAbortControllerSignal()
+    : new AbortController();
   if (nodeResponse?.once) {
     const closeEventListener: EventListener = () => {
       if (!controller.signal.aborted) {

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -283,7 +283,7 @@ export function sendNodeResponse(
     // @ts-expect-error - headersInit is a private property
     fetchResponse.headers?.headersInit &&
     // @ts-expect-error - headersInit is a private property
-    !Array.isArray(fetchResponse.headers.headersInit) &&
+    !isArray(fetchResponse.headers.headersInit) &&
     // @ts-expect-error - headersInit is a private property
     !fetchResponse.headers.headersInit.get &&
     // @ts-expect-error - map is a private property
@@ -604,4 +604,8 @@ export function ensureDisposableStackRegisteredForTerminateEvents(
       });
     }
   }
+}
+
+export function isArray<T>(value: any): value is T[] {
+  return value?.length && value?.map && value?.slice && value?.splice;
 }

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -281,35 +281,35 @@ export function sendNodeResponse(
   }
   // @ts-expect-error - headersInit is a private property
   if (fetchResponse.headers?.headersInit && !fetchResponse.headers?._map) {
-    // @ts-expect-error - headersInit is a private property
     serverResponse.writeHead(
       fetchResponse.status,
       fetchResponse.statusText,
+      // @ts-expect-error - headersInit is a private property
       fetchResponse.headers.headersInit,
     );
-    // @ts-expect-error - setHeaders exist
-  } else if (serverResponse.setHeaders) {
-    // @ts-expect-error - setHeaders exist
-    serverResponse.setHeaders(fetchResponse.headers);
   } else {
-    serverResponse.statusCode = fetchResponse.status;
-    serverResponse.statusMessage = fetchResponse.statusText;
-
-    let setCookiesSet = false;
-    fetchResponse.headers.forEach((value, key) => {
-      if (key === 'set-cookie') {
-        if (setCookiesSet) {
-          return;
+    // @ts-expect-error - setHeaders exist
+    if (serverResponse.setHeaders) {
+      // @ts-expect-error - setHeaders exist
+      serverResponse.setHeaders(fetchResponse.headers);
+    } else {
+      let setCookiesSet = false;
+      fetchResponse.headers.forEach((value, key) => {
+        if (key === 'set-cookie') {
+          if (setCookiesSet) {
+            return;
+          }
+          setCookiesSet = true;
+          const setCookies = fetchResponse.headers.getSetCookie?.();
+          if (setCookies) {
+            serverResponse.setHeader('set-cookie', setCookies);
+            return;
+          }
         }
-        setCookiesSet = true;
-        const setCookies = fetchResponse.headers.getSetCookie?.();
-        if (setCookies) {
-          serverResponse.setHeader('set-cookie', setCookies);
-          return;
-        }
-      }
-      serverResponse.setHeader(key, value);
-    });
+        serverResponse.setHeader(key, value);
+      });
+    }
+    serverResponse.writeHead(fetchResponse.status, fetchResponse.statusText);
   }
 
   // @ts-expect-error - Handle the case where the response is a string

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -288,7 +288,7 @@ export function sendNodeResponse(
     // @ts-expect-error - headersInit is a private property
     fetchResponse.headers?.headersInit &&
     // @ts-expect-error - headersInit is a private property
-    !isArray(fetchResponse.headers.headersInit) &&
+    !Array.isArray(fetchResponse.headers.headersInit) &&
     // @ts-expect-error - headersInit is a private property
     !fetchResponse.headers.headersInit.get &&
     // @ts-expect-error - map is a private property
@@ -611,10 +611,6 @@ export function ensureDisposableStackRegisteredForTerminateEvents(
       });
     }
   }
-}
-
-export function isArray<T>(value: any): value is T[] {
-  return value?.length != null && value?.map && value?.slice && value?.splice;
 }
 
 export class CustomAbortControllerSignal

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -607,5 +607,5 @@ export function ensureDisposableStackRegisteredForTerminateEvents(
 }
 
 export function isArray<T>(value: any): value is T[] {
-  return value?.length && value?.map && value?.slice && value?.splice;
+  return value?.length != null && value?.map && value?.slice && value?.splice;
 }

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -282,7 +282,15 @@ export function sendNodeResponse(
   // @ts-expect-error - headersInit is a private property
   if (fetchResponse.headers?.headersInit && !fetchResponse.headers?._map) {
     // @ts-expect-error - headersInit is a private property
-    serverResponse.writeHead(fetchResponse.status, fetchResponse.headers.headersInit);
+    serverResponse.writeHead(
+      fetchResponse.status,
+      fetchResponse.statusText,
+      fetchResponse.headers.headersInit,
+    );
+    // @ts-expect-error - setHeaders exist
+  } else if (serverResponse.setHeaders) {
+    // @ts-expect-error - setHeaders exist
+    serverResponse.setHeaders(fetchResponse.headers);
   } else {
     serverResponse.statusCode = fetchResponse.status;
     serverResponse.statusMessage = fetchResponse.statusText;

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -287,7 +287,9 @@ export function sendNodeResponse(
     // @ts-expect-error - headersInit is a private property
     !fetchResponse.headers.headersInit.get &&
     // @ts-expect-error - map is a private property
-    !fetchResponse.headers._map
+    !fetchResponse.headers._map &&
+    // @ts-expect-error - _setCookies is a private property
+    !fetchResponse.headers._setCookies?.length
   ) {
     serverResponse.writeHead(
       fetchResponse.status,

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -298,6 +298,15 @@ export function sendNodeResponse(
     serverResponse.setHeader(key, value);
   });
 
+  // @ts-expect-error - Handle the case where the response is a string
+  if (fetchResponse['bodyType'] === 'String') {
+    return handleMaybePromise(
+      // @ts-expect-error - bodyInit is a private property
+      () => safeWrite(fetchResponse.bodyInit, serverResponse),
+      () => endResponse(serverResponse),
+    );
+  }
+
   // Optimizations for node-fetch
   const bufOfRes: Buffer =
     // @ts-expect-error - _buffer is a private property

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -279,8 +279,16 @@ export function sendNodeResponse(
     endResponse(serverResponse);
     return;
   }
-  // @ts-expect-error - headersInit is a private property
-  if (fetchResponse.headers?.headersInit && !fetchResponse.headers?._map) {
+  if (
+    // @ts-expect-error - headersInit is a private property
+    fetchResponse.headers?.headersInit &&
+    // @ts-expect-error - headersInit is a private property
+    !Array.isArray(fetchResponse.headers.headersInit) &&
+    // @ts-expect-error - headersInit is a private property
+    !fetchResponse.headers.headersInit.get &&
+    // @ts-expect-error - map is a private property
+    !fetchResponse.headers._map
+  ) {
     serverResponse.writeHead(
       fetchResponse.status,
       fetchResponse.statusText,

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -115,10 +115,7 @@ export function normalizeNodeRequest(
       }
     }
   }
-  const controller =
-    fetchAPI.Request === globalThis.Request
-      ? new AbortController()
-      : new CustomAbortControllerSignal();
+  const controller = new AbortController();
   if (nodeResponse?.once) {
     const closeEventListener: EventListener = () => {
       if (!controller.signal.aborted) {

--- a/packages/server/test/reproductions.spec.ts
+++ b/packages/server/test/reproductions.spec.ts
@@ -94,12 +94,23 @@ for (const largeBody of bodies) {
     app.use(compression());
 
     const echoAdapter = createServerAdapter(req =>
-      req.json().then(body =>
-        Response.json({
-          body,
-          url: req.url,
-        }),
-      ),
+      req
+        .json()
+        .then(body =>
+          Response.json({
+            body,
+            url: req.url,
+          }),
+        )
+        .catch(error =>
+          Response.json({
+            error: {
+              name: error.name,
+              message: error.message,
+              stack: error.stack,
+            },
+          }),
+        ),
     );
 
     app.use('/my-path', echoAdapter);

--- a/packages/server/test/server.bench.ts
+++ b/packages/server/test/server.bench.ts
@@ -1,0 +1,49 @@
+import { createServer } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { bench, BenchOptions, describe } from 'vitest';
+import { createServerAdapter, Response } from '@whatwg-node/server';
+
+const isCI = !!process.env['CI'];
+
+function useNumberEnv(envName: string, defaultValue: number): number {
+  const value = process.env[envName];
+  if (!value) {
+    return defaultValue;
+  }
+  return parseInt(value, 10);
+}
+
+const duration = useNumberEnv('BENCH_DURATION', isCI ? 30000 : 5000);
+const warmupTime = useNumberEnv('BENCH_WARMUP_TIME', isCI ? 5000 : 1000);
+const warmupIterations = useNumberEnv('BENCH_WARMUP_ITERATIONS', isCI ? 10 : 5);
+const benchConfig: BenchOptions = {
+  time: duration,
+  warmupTime,
+  warmupIterations,
+  throws: true,
+};
+
+describe('Simple JSON Response', () => {
+  const simpleNodeServer = createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ hello: 'world' }));
+  });
+  const simpleNodePort = (simpleNodeServer.listen(0).address() as AddressInfo).port;
+  bench(
+    'node:http',
+    () => fetch(`http://localhost:${simpleNodePort}`).then(res => res.json()),
+    benchConfig,
+  );
+
+  const whatwgNodeServer = (
+    createServer(createServerAdapter(() => Response.json({ hello: 'world' })))
+      .listen(0)
+      .address() as AddressInfo
+  ).port;
+
+  bench(
+    '@whatwg-node/server',
+    () => fetch(`http://localhost:${whatwgNodeServer}`).then(res => res.json()),
+    benchConfig,
+  );
+});

--- a/packages/server/test/server.bench.ts
+++ b/packages/server/test/server.bench.ts
@@ -35,15 +35,30 @@ describe('Simple JSON Response', () => {
     benchConfig,
   );
 
-  const whatwgNodeServer = (
+  const whatwgNodeServerWithPonyfills = (
     createServer(createServerAdapter(() => Response.json({ hello: 'world' })))
       .listen(0)
       .address() as AddressInfo
   ).port;
 
   bench(
-    '@whatwg-node/server',
-    () => fetch(`http://localhost:${whatwgNodeServer}`).then(res => res.json()),
+    '@whatwg-node/server w/ ponyfills',
+    () => fetch(`http://localhost:${whatwgNodeServerWithPonyfills}`).then(res => res.json()),
+    benchConfig,
+  );
+
+  const whatwgNodeWithNative = (
+    createServer(
+      createServerAdapter(() => globalThis.Response.json({ hello: 'world ' }), {
+        fetchAPI: globalThis,
+      }),
+    )
+      .listen(0)
+      .address() as AddressInfo
+  ).port;
+  bench(
+    '@whatwg-node/server w/ native',
+    () => fetch(`http://localhost:${whatwgNodeWithNative}`).then(res => res.json()),
     benchConfig,
   );
 });

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -14,7 +14,7 @@
     "e2e",
     "examples",
     "**/dist",
-    "./vitest.config.ts",
-    "./vitest.projects.ts"
+    "vitest.config.ts",
+    "vitest.projects.ts"
   ]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -13,6 +13,8 @@
     "packages/testing",
     "e2e",
     "examples",
-    "**/dist"
+    "**/dist",
+    "./vitest.config.ts",
+    "./vitest.projects.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,13 @@
       "fetchache": ["packages/fetchache/src/index.ts"]
     }
   },
-  "include": ["packages", "examples", "uwsUtils.d.ts", "scheduler-tracing.d.ts"],
+  "include": [
+    "packages",
+    "examples",
+    "uwsUtils.d.ts",
+    "scheduler-tracing.d.ts",
+    "./vitest.config.ts",
+    "./vitest.projects.ts"
+  ],
   "exclude": ["**/node_modules", "**/test-files", "**/dist", "**/e2e", "**/benchmark"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,8 +40,8 @@
     "examples",
     "uwsUtils.d.ts",
     "scheduler-tracing.d.ts",
-    "./vitest.config.ts",
-    "./vitest.projects.ts"
+    "vitest.config.ts",
+    "vitest.projects.ts"
   ],
   "exclude": ["**/node_modules", "**/test-files", "**/dist", "**/e2e", "**/benchmark"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,6 @@
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+});

--- a/vitest.projects.ts
+++ b/vitest.projects.ts
@@ -1,0 +1,15 @@
+import { defineWorkspace } from 'vitest/config';
+
+export default defineWorkspace([
+  {
+    extends: './vitest.config.ts',
+    test: {
+      name: 'bench',
+      benchmark: {
+        include: ['**/*.bench.ts'],
+        reporters: ['verbose'],
+        outputJson: 'bench/results.json',
+      },
+    },
+  },
+]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,7 +2297,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
   integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
@@ -2892,6 +2892,106 @@
     tmp "^0.2.1"
     upath "^1.1.0"
 
+"@rollup/rollup-android-arm-eabi@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.2.tgz#c228d00a41f0dbd6fb8b7ea819bbfbf1c1157a10"
+  integrity sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg==
+
+"@rollup/rollup-android-arm64@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.2.tgz#e2b38d0c912169fd55d7e38d723aada208d37256"
+  integrity sha512-13unNoZ8NzUmnndhPTkWPWbX3vtHodYmy+I9kuLxN+F+l+x3LdVF7UCu8TWVMt1POHLh6oDHhnOA04n8oJZhBw==
+
+"@rollup/rollup-darwin-arm64@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.2.tgz#1fddb3690f2ae33df16d334c613377f05abe4878"
+  integrity sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==
+
+"@rollup/rollup-darwin-x64@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.2.tgz#818298d11c8109e1112590165142f14be24b396d"
+  integrity sha512-47N4hxa01a4x6XnJoskMKTS8XZ0CZMd8YTbINbi+w03A2w4j1RTlnGHOz/P0+Bg1LaVL6ufZyNprSg+fW5nYQQ==
+
+"@rollup/rollup-freebsd-arm64@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.2.tgz#91a28dc527d5bed7f9ecf0e054297b3012e19618"
+  integrity sha512-8t6aL4MD+rXSHHZUR1z19+9OFJ2rl1wGKvckN47XFRVO+QL/dUSpKA2SLRo4vMg7ELA8pzGpC+W9OEd1Z/ZqoQ==
+
+"@rollup/rollup-freebsd-x64@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.2.tgz#28acadefa76b5c7bede1576e065b51d335c62c62"
+  integrity sha512-C+AyHBzfpsOEYRFjztcYUFsH4S7UsE9cDtHCtma5BK8+ydOZYgMmWg1d/4KBytQspJCld8ZIujFMAdKG1xyr4Q==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.2.tgz#819691464179cbcd9a9f9d3dc7617954840c6186"
+  integrity sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q==
+
+"@rollup/rollup-linux-arm-musleabihf@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.2.tgz#d149207039e4189e267e8724050388effc80d704"
+  integrity sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg==
+
+"@rollup/rollup-linux-arm64-gnu@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.2.tgz#fa72ebddb729c3c6d88973242f1a2153c83e86ec"
+  integrity sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg==
+
+"@rollup/rollup-linux-arm64-musl@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.2.tgz#2054216e34469ab8765588ebf343d531fc3c9228"
+  integrity sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg==
+
+"@rollup/rollup-linux-loongarch64-gnu@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.2.tgz#818de242291841afbfc483a84f11e9c7a11959bc"
+  integrity sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw==
+
+"@rollup/rollup-linux-powerpc64le-gnu@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.2.tgz#0bb4cb8fc4a2c635f68c1208c924b2145eb647cb"
+  integrity sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q==
+
+"@rollup/rollup-linux-riscv64-gnu@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.2.tgz#4b3b8e541b7b13e447ae07774217d98c06f6926d"
+  integrity sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg==
+
+"@rollup/rollup-linux-riscv64-musl@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.2.tgz#e065405e67d8bd64a7d0126c931bd9f03910817f"
+  integrity sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg==
+
+"@rollup/rollup-linux-s390x-gnu@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.2.tgz#dda3265bbbfe16a5d0089168fd07f5ebb2a866fe"
+  integrity sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ==
+
+"@rollup/rollup-linux-x64-gnu@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.2.tgz#90993269b8b995b4067b7b9d72ff1c360ef90a17"
+  integrity sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==
+
+"@rollup/rollup-linux-x64-musl@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.2.tgz#fdf5b09fd121eb8d977ebb0fda142c7c0167b8de"
+  integrity sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA==
+
+"@rollup/rollup-win32-arm64-msvc@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.2.tgz#6397e1e012db64dfecfed0774cb9fcf89503d716"
+  integrity sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg==
+
+"@rollup/rollup-win32-ia32-msvc@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.2.tgz#df0991464a52a35506103fe18d29913bf8798a0c"
+  integrity sha512-dt1llVSGEsGKvzeIO76HToiYPNPYPkmjhMHhP00T9S4rDern8P2ZWvWAQUEJ+R1UdMWJ/42i/QqJ2WV765GZcA==
+
+"@rollup/rollup-win32-x64-msvc@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.2.tgz#8dae04d01a2cbd84d6297d99356674c6b993f0fc"
+  integrity sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA==
+
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
@@ -3154,7 +3254,7 @@
   resolved "https://registry.yarnpkg.com/@types/deno/-/deno-2.3.0.tgz#ee3febb74e9fddf05fa71ac769538ecf17e32c03"
   integrity sha512-/4SyefQpKjwNKGkq9qG3Ln7MazfbWKvydyVFBnXzP5OQA4u1paoFtaOe1iHKycIWHHkhYag0lPxyheThV1ijzw==
 
-"@types/estree@^1.0.6":
+"@types/estree@1.0.7", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
   integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
@@ -3542,6 +3642,65 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.7.2.tgz#7fd81d89e34a711d398ca87f6d5842735d49721e"
   integrity sha512-friS8NEQfHaDbkThxopGk+LuE5v3iY0StruifjQEt7SLbA46OnfgMO15sOTkbpJkol6RB+1l1TYPXh0sCddpvA==
 
+"@vitest/expect@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.1.3.tgz#bbca175cd2f23d7de9448a215baed8f3d7abd7b7"
+  integrity sha512-7FTQQuuLKmN1Ig/h+h/GO+44Q1IlglPlR2es4ab7Yvfx+Uk5xsv+Ykk+MEt/M2Yn/xGmzaLKxGw2lgy2bwuYqg==
+  dependencies:
+    "@vitest/spy" "3.1.3"
+    "@vitest/utils" "3.1.3"
+    chai "^5.2.0"
+    tinyrainbow "^2.0.0"
+
+"@vitest/mocker@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.1.3.tgz#121d0f2fcca20c9ccada9e2d6e761f7fc687f4ce"
+  integrity sha512-PJbLjonJK82uCWHjzgBJZuR7zmAOrSvKk1QBxrennDIgtH4uK0TB1PvYmc0XBCigxxtiAVPfWtAdy4lpz8SQGQ==
+  dependencies:
+    "@vitest/spy" "3.1.3"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.17"
+
+"@vitest/pretty-format@3.1.3", "@vitest/pretty-format@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.1.3.tgz#760b9eab5f253d7d2e7dcd28ef34570f584023d4"
+  integrity sha512-i6FDiBeJUGLDKADw2Gb01UtUNb12yyXAqC/mmRWuYl+m/U9GS7s8us5ONmGkGpUUo7/iAYzI2ePVfOZTYvUifA==
+  dependencies:
+    tinyrainbow "^2.0.0"
+
+"@vitest/runner@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.1.3.tgz#b268fa90fca38fab363f1107f057c0a2a141ee45"
+  integrity sha512-Tae+ogtlNfFei5DggOsSUvkIaSuVywujMj6HzR97AHK6XK8i3BuVyIifWAm/sE3a15lF5RH9yQIrbXYuo0IFyA==
+  dependencies:
+    "@vitest/utils" "3.1.3"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.1.3.tgz#39a8f9f8c6ba732ffde59adeacf0a549bef11e76"
+  integrity sha512-XVa5OPNTYUsyqG9skuUkFzAeFnEzDp8hQu7kZ0N25B1+6KjGm4hWLtURyBbsIAOekfWQ7Wuz/N/XXzgYO3deWQ==
+  dependencies:
+    "@vitest/pretty-format" "3.1.3"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+
+"@vitest/spy@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.1.3.tgz#ca81e2b4f0c3d6c75f35defa77c3336f39c8f605"
+  integrity sha512-x6w+ctOEmEXdWaa6TO4ilb7l9DxPR5bwEb6hILKuxfU1NqWT2mpJD9NJN7t3OTfxmVlOMrvtoFJGdgyzZ605lQ==
+  dependencies:
+    tinyspy "^3.0.2"
+
+"@vitest/utils@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.1.3.tgz#4f31bdfd646cd82d30bfa730d7410cb59d529669"
+  integrity sha512-2Ltrpht4OmHO9+c/nmHtF09HWiyWdworqnHIwjfvDyWjuwKbdkcS9AnhsDn+8E2RM4x++foD1/tNuLPVvWG1Rg==
+  dependencies:
+    "@vitest/pretty-format" "3.1.3"
+    loupe "^3.1.3"
+    tinyrainbow "^2.0.0"
+
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
@@ -3844,6 +4003,11 @@ as-table@^1.0.36:
   integrity sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==
   dependencies:
     printable-characters "^1.0.42"
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 ast-types-flow@^0.0.8:
   version "0.0.8"
@@ -4180,6 +4344,11 @@ bytes@3.1.2, bytes@^3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 cacache@^18.0.0, cacache@^18.0.3:
   version "18.0.4"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-18.0.4.tgz#4601d7578dadb59c66044e157d02a3314682d6a5"
@@ -4270,6 +4439,17 @@ caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001716:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz#dae13a9c80d517c30c6197515a96131c194d8f82"
   integrity sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==
 
+chai@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.2.0.tgz#1358ee106763624114addf84ab02697e411c9c05"
+  integrity sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
+
 chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -4297,6 +4477,11 @@ charenc@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==
+
+check-error@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
+  integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
 
 check-more-types@2.24.0:
   version "2.24.0"
@@ -4635,6 +4820,11 @@ dedent@^1.0.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.6.0.tgz#79d52d6389b1ffa67d2bcef59ba51847a9d503b2"
   integrity sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==
 
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
+
 deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -4966,6 +5156,11 @@ es-iterator-helpers@^1.2.1:
     iterator.prototype "^1.1.4"
     safe-array-concat "^1.1.3"
 
+es-module-lexer@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
+
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
@@ -5004,7 +5199,7 @@ es6-promisify@^7.0.0:
   resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-7.0.0.tgz#9a710008dd6a4ab75a89e280bad787bfb749927b"
   integrity sha512-ginqzK3J90Rd4/Yz7qRrqUeIpe3TwSXTPPZtPne7tGBPeAaQiU8qt4fpKApnxHcq1AwtUdHVg5P77x/yrggG8Q==
 
-esbuild@0.25.4, esbuild@~0.25.0:
+esbuild@0.25.4, esbuild@^0.25.0, esbuild@~0.25.0:
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.4.tgz#bb9a16334d4ef2c33c7301a924b8b863351a0854"
   integrity sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==
@@ -5319,6 +5514,13 @@ estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -5391,6 +5593,11 @@ exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
+
+expect-type@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.1.tgz#af76d8b357cf5fa76c41c09dafb79c549e75f71f"
+  integrity sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==
 
 expect@^29.7.0:
   version "29.7.0"
@@ -6004,6 +6211,11 @@ globby@^13.1.3:
     ignore "^5.2.4"
     merge2 "^1.4.1"
     slash "^4.0.0"
+
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 google-protobuf@^3.5.0:
   version "3.21.4"
@@ -7427,6 +7639,11 @@ loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loupe@^3.1.0, loupe@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.1.3.tgz#042a8f7986d77f3d0f98ef7990a2b2fef18b0fd2"
+  integrity sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==
+
 lowercase-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
@@ -7448,6 +7665,13 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+magic-string@^0.30.17:
+  version "0.30.17"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
+  integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
 
 make-dir@^3.1.0:
   version "3.1.0"
@@ -7758,7 +7982,7 @@ nano-spawn@^1.0.0:
   resolved "https://registry.yarnpkg.com/nano-spawn/-/nano-spawn-1.0.1.tgz#c8e4c1e133e567e3efba44041dcfb12113d861b6"
   integrity sha512-BfcvzBlUTxSDWfT+oH7vd6CbUV+rThLLHCIym/QO6GGLBsyVXleZs00fto2i2jzC/wPiBYk5jyOmpXWg4YopiA==
 
-nanoid@^3.3.6:
+nanoid@^3.3.6, nanoid@^3.3.8:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
@@ -8363,6 +8587,11 @@ pathe@^2.0.3:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
+pathval@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.0.tgz#7e2550b422601d4f6b8e26f1301bc8f15a741a25"
+  integrity sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==
+
 pause-stream@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
@@ -8479,6 +8708,15 @@ postcss@8.4.31:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postcss@^8.5.3:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.3.tgz#1463b6f1c7fb16fe258736cba29a2de35237eafb"
+  integrity sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==
+  dependencies:
+    nanoid "^3.3.8"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -8944,6 +9182,35 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rollup@^4.34.9:
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.40.2.tgz#778e88b7a197542682b3e318581f7697f55f0619"
+  integrity sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==
+  dependencies:
+    "@types/estree" "1.0.7"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.40.2"
+    "@rollup/rollup-android-arm64" "4.40.2"
+    "@rollup/rollup-darwin-arm64" "4.40.2"
+    "@rollup/rollup-darwin-x64" "4.40.2"
+    "@rollup/rollup-freebsd-arm64" "4.40.2"
+    "@rollup/rollup-freebsd-x64" "4.40.2"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.40.2"
+    "@rollup/rollup-linux-arm-musleabihf" "4.40.2"
+    "@rollup/rollup-linux-arm64-gnu" "4.40.2"
+    "@rollup/rollup-linux-arm64-musl" "4.40.2"
+    "@rollup/rollup-linux-loongarch64-gnu" "4.40.2"
+    "@rollup/rollup-linux-powerpc64le-gnu" "4.40.2"
+    "@rollup/rollup-linux-riscv64-gnu" "4.40.2"
+    "@rollup/rollup-linux-riscv64-musl" "4.40.2"
+    "@rollup/rollup-linux-s390x-gnu" "4.40.2"
+    "@rollup/rollup-linux-x64-gnu" "4.40.2"
+    "@rollup/rollup-linux-x64-musl" "4.40.2"
+    "@rollup/rollup-win32-arm64-msvc" "4.40.2"
+    "@rollup/rollup-win32-ia32-msvc" "4.40.2"
+    "@rollup/rollup-win32-x64-msvc" "4.40.2"
+    fsevents "~2.3.2"
+
 router@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/router/-/router-2.2.0.tgz#019be620b711c87641167cc79b99090f00b146ef"
@@ -9240,6 +9507,11 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.0, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
@@ -9334,7 +9606,7 @@ sonic-boom@^4.0.1:
   dependencies:
     atomic-sleep "^1.0.0"
 
-source-map-js@^1.0.2:
+source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -9427,6 +9699,11 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 stacktracey@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/stacktracey/-/stacktracey-2.1.8.tgz#bf9916020738ce3700d1323b32bd2c91ea71199d"
@@ -9458,6 +9735,11 @@ statuses@2.0.1, statuses@^2.0.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+std-env@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
+  integrity sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==
 
 stoppable@1.1.0:
   version "1.1.0"
@@ -9715,6 +9997,16 @@ through@2, through@~2.3, through@~2.3.1:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
 tinyglobby@^0.2.13:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.13.tgz#a0e46515ce6cbcd65331537e57484af5a7b2ff7e"
@@ -9722,6 +10014,21 @@ tinyglobby@^0.2.13:
   dependencies:
     fdir "^6.4.4"
     picomatch "^4.0.2"
+
+tinypool@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.0.2.tgz#706193cc532f4c100f66aa00b01c42173d9051b2"
+  integrity sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==
+
+tinyrainbow@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
+  integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
+
+tinyspy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
+  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -9806,6 +10113,11 @@ ts-node@10.9.2:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
+
+tsconfck@^3.0.3:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-3.1.5.tgz#2f07f9be6576825e7a77470a5304ce06c7746e61"
+  integrity sha512-CLDfGgUp7XPswWnezWwsCRxNmgQjhYq3VXHM0/XIRxhVrKw0M1if9agzryh1QS3nxjCROvV+xWxoJO1YctzzWg==
 
 tsconfig-paths@4.2.0:
   version "4.2.0"
@@ -10147,6 +10459,67 @@ vary@^1.1.2, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+vite-node@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.1.3.tgz#d021ced40b5a057305eaea9ce62c610c33b60a48"
+  integrity sha512-uHV4plJ2IxCl4u1up1FQRrqclylKAogbtBfOTwcuJ28xFi+89PZ57BRh+naIRvH70HPwxy5QHYzg1OrEaC7AbA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.4.0"
+    es-module-lexer "^1.7.0"
+    pathe "^2.0.3"
+    vite "^5.0.0 || ^6.0.0"
+
+vite-tsconfig-paths@5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz#d9a71106a7ff2c1c840c6f1708042f76a9212ed4"
+  integrity sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==
+  dependencies:
+    debug "^4.1.1"
+    globrex "^0.1.2"
+    tsconfck "^3.0.3"
+
+"vite@^5.0.0 || ^6.0.0":
+  version "6.3.5"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-6.3.5.tgz#fec73879013c9c0128c8d284504c6d19410d12a3"
+  integrity sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==
+  dependencies:
+    esbuild "^0.25.0"
+    fdir "^6.4.4"
+    picomatch "^4.0.2"
+    postcss "^8.5.3"
+    rollup "^4.34.9"
+    tinyglobby "^0.2.13"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.1.3.tgz#0b0b01932408cd3af61867f4468d28bd83406ffb"
+  integrity sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==
+  dependencies:
+    "@vitest/expect" "3.1.3"
+    "@vitest/mocker" "3.1.3"
+    "@vitest/pretty-format" "^3.1.3"
+    "@vitest/runner" "3.1.3"
+    "@vitest/snapshot" "3.1.3"
+    "@vitest/spy" "3.1.3"
+    "@vitest/utils" "3.1.3"
+    chai "^5.2.0"
+    debug "^4.4.0"
+    expect-type "^1.2.1"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+    std-env "^3.9.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.2"
+    tinyglobby "^0.2.13"
+    tinypool "^1.0.2"
+    tinyrainbow "^2.0.0"
+    vite "^5.0.0 || ^6.0.0"
+    vite-node "3.1.3"
+    why-is-node-running "^2.3.0"
+
 wait-on@8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-8.0.3.tgz#a23c684115d68059d739ce4eb18a3f88088d2d16"
@@ -10257,6 +10630,14 @@ which@^4.0.0:
   integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
   dependencies:
     isexe "^3.1.1"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 wide-align@^1.1.2, wide-align@^1.1.5:
   version "1.1.5"


### PR DESCRIPTION
- Avoid creating `AbortController` and `AbortSignal` if not needed with `new Request` because it is expensive
- Avoid creating a map for `Headers` and try to re-use the init object for `Headers` for performance with a single-line `writeHead`.
- Avoid creating `Buffer` for `string` bodies for performance
- Use `setHeaders` which accepts `Headers` since Node 18 if needed to forward `Headers` to Node