### PR TITLE
Avoid Node's promise pipeline by piping streams directly

### DIFF
--- a/.changeset/purple-towns-begin.md
+++ b/.changeset/purple-towns-begin.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/node-fetch': patch
+---
+
+Avoid Node's promise pipeline by piping streams directly

--- a/packages/node-fetch/src/fetchNodeHttp.ts
+++ b/packages/node-fetch/src/fetchNodeHttp.ts
@@ -10,9 +10,9 @@ import {
   endStream,
   getHeadersObj,
   isNodeReadable,
+  pipeThrough,
   safeWrite,
   shouldRedirect,
-  wrapIncomingMessageWithPassthrough,
 } from './utils.js';
 
 function getRequestFnForProtocol(url: string) {
@@ -117,9 +117,9 @@ export function fetchNodeHttp<TResponseJSON = any, TRequestJSON = any>(
         }
 
         if (outputStream != null) {
-          outputStream = wrapIncomingMessageWithPassthrough({
-            incomingMessage: nodeResponse,
-            passThrough: outputStream,
+          pipeThrough({
+            src: nodeResponse,
+            dest: outputStream,
             signal,
             onError: reject,
           });

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -1,7 +1,5 @@
 import { once } from 'node:events';
-import { IncomingMessage } from 'node:http';
-import { PassThrough, Readable, Writable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
+import { Readable, Writable } from 'node:stream';
 
 function isHeadersInstance(obj: any): obj is Headers {
   return obj?.forEach != null;
@@ -51,30 +49,52 @@ export function shouldRedirect(status?: number): boolean {
   return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
 }
 
-export function wrapIncomingMessageWithPassthrough({
-  incomingMessage,
+export function pipeThrough({
+  src,
+  dest,
   signal,
-  passThrough = new PassThrough(),
-  onError = (e: Error) => {
-    passThrough.destroy(e);
-  },
+  onError,
 }: {
-  incomingMessage: IncomingMessage;
-  passThrough?: PassThrough | undefined;
+  src: Readable;
+  dest: Writable;
   signal?: AbortSignal | undefined;
-  onError?: (e: Error) => void;
+  onError?: ((e: Error) => void) | undefined;
 }) {
-  pipeline(incomingMessage, passThrough, {
-    signal,
-    end: true,
-  })
-    .then(() => {
-      if (!incomingMessage.destroyed) {
-        incomingMessage.resume();
+  if (onError) {
+    // listen for errors on the destination stream if necessary. if the readable
+    // stream (src) emits an error, the writable destination (dest) will be
+    // destroyed with that error (see below)
+    dest.once('error', onError);
+  }
+
+  src.once('error', (e: Error) => {
+    // if the readable stream (src) emits an error during pipe, the writable
+    // destination (dest) is not closed automatically. that needs to be
+    // done manually. the readable stream is closed when error is emitted,
+    // so only the writable destination needs to be destroyed
+    dest.destroy(e);
+  });
+
+  if (signal) {
+    function handleAbort() {
+      try {
+        signal!.throwIfAborted();
+      } catch (abortError: any) {
+        // destroying the src stream will destroy the dest stream as well
+        src.destroy(abortError);
       }
-    })
-    .catch(onError);
-  return passThrough;
+    }
+    if (signal.aborted) {
+      // if the signal is already aborted, we can just destroy the
+      // src stream and not start pipe at all
+      handleAbort();
+      return;
+    }
+
+    signal.addEventListener('abort', handleAbort, { once: true });
+  }
+
+  src.pipe(dest, { end: true /* already default */ });
 }
 
 export function endStream(stream: { end: () => void }) {

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -1,5 +1,5 @@
 import { once } from 'node:events';
-import { Readable, Writable } from 'node:stream';
+import { finished, Readable, Writable } from 'node:stream';
 
 function isHeadersInstance(obj: any): obj is Headers {
   return obj?.forEach != null;
@@ -81,7 +81,7 @@ export function pipeThrough({
       src.destroy(new AbortError());
     }
     signal.addEventListener('abort', onAbort, { once: true });
-    src.once('close', () => signal.removeEventListener('abort', onAbort));
+    finished(src, () => signal.removeEventListener('abort', onAbort));
   }
 
   src.pipe(dest, { end: true /* already default */ });

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -81,7 +81,7 @@ export function pipeThrough({
       src.destroy(new AbortError());
     }
     signal.addEventListener('abort', onAbort, { once: true });
-    src.once('end', () => signal.removeEventListener('abort', onAbort));
+    src.once('close', () => signal.removeEventListener('abort', onAbort));
   }
 
   src.pipe(dest, { end: true /* already default */ });

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -81,7 +81,7 @@ export function pipeThrough({
       src.destroy(new AbortError());
     }
     signal.addEventListener('abort', onAbort, { once: true });
-    src.once('close', () => signal.removeEventListener('abort', onAbort));
+    src.once('end', () => signal.removeEventListener('abort', onAbort));
   }
 
   src.pipe(dest, { end: true /* already default */ });

--- a/packages/node-fetch/src/utils.ts
+++ b/packages/node-fetch/src/utils.ts
@@ -76,6 +76,7 @@ export function pipeThrough({
   });
 
   if (signal) {
+    // this is faster than `import('node:signal').addAbortSignal(signal, src)`
     function onAbort() {
       src.destroy(new AbortError());
     }


### PR DESCRIPTION
Alternative to and closes #2632

This repo does not have proper benchmarking set up to have detected this regression, but other repo's have - like feTS:
- With node promise pipeline https://github.com/ardatan/feTS/pull/2915
- Without node promise pipeline https://github.com/ardatan/feTS/pull/2918

~9% increase in perf benchmarking Hive Gateway, memory consumption feels lower too
~20% increase in perf benchmarking feTS
