### PR TITLE
fix: propagate response body and pipeTo stream errors

### DIFF
--- a/.changeset/response-stream-destroy.md
+++ b/.changeset/response-stream-destroy.md
@@ -1,5 +1,8 @@
 ---
 '@whatwg-node/server': patch
+'@whatwg-node/node-fetch': patch
 ---
 
-Destroy the Node response when the WHATWG response body stream errors or is aborted, so the client socket is closed (RST / ECONNRESET) instead of hanging.
+Destroy the Node response when the response body stream errors or is aborted, and propagate `Readable.destroy(err)` in the node-fetch stream ponyfill so piped sockets close with RST / ECONNRESET instead of hanging.
+
+Also make ponyfill `ReadableStream.pipeTo()` reject when the destination write fails (after aborting the writer), instead of resolving successfully.

--- a/.changeset/response-stream-destroy.md
+++ b/.changeset/response-stream-destroy.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/server': patch
+---
+
+Destroy the Node response when the WHATWG response body stream errors or is aborted, so the client socket is closed (RST / ECONNRESET) instead of hanging.

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -125,17 +125,20 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
                   () => {
                     callback(null);
                   },
-                  err => {
-                    callback(err);
+                  cancelErr => {
+                    callback(cancelErr);
                   },
                 );
               }
-            } catch (err: any) {
-              callback(err);
+            } catch (cancelErr: any) {
+              callback(cancelErr);
               return;
             }
+            callback(null);
+            return;
           }
-          callback(null);
+          // No cancel hook: propagate destroy(err) so piped destinations observe the failure (#3011)
+          callback(err ?? null);
         },
       });
     }
@@ -192,21 +195,27 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
     };
   }
 
-  [Symbol.asyncIterator](_options?: ReadableStreamIteratorOptions): ReadableStreamAsyncIterator<T> {
-    const iterator = this.readable[Symbol.asyncIterator]();
+  [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): ReadableStreamAsyncIterator<T> {
+    const preventCancel = options?.preventCancel === true;
+    // Node's default async iterator destroys on return; honor preventCancel via destroyOnReturn.
+    const iterator = (
+      typeof this.readable.iterator === 'function'
+        ? this.readable.iterator({ destroyOnReturn: !preventCancel })
+        : this.readable[Symbol.asyncIterator]()
+    ) as AsyncIterator<any>;
     const iterable = {
       [Symbol.asyncIterator]() {
         return this;
       },
       [Symbol.asyncDispose]: async () => {
         await iterator.return?.();
-        if (!this.readable.destroyed) {
+        if (!preventCancel && !this.readable.destroyed) {
           this.readable.destroy();
         }
       },
       next: () => iterator.next(),
       return: () => {
-        if (!this.readable.destroyed) {
+        if (!preventCancel && !this.readable.destroyed) {
           this.readable.destroy();
         }
         return iterator.return?.() || fakePromise({ done: true, value: undefined });
@@ -221,8 +230,8 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
     return iterable as unknown as ReadableStreamAsyncIterator<T>;
   }
 
-  values(_options?: ReadableStreamIteratorOptions): ReadableStreamAsyncIterator<T> {
-    return this[Symbol.asyncIterator]();
+  values(options?: ReadableStreamIteratorOptions): ReadableStreamAsyncIterator<T> {
+    return this[Symbol.asyncIterator](options);
   }
 
   tee(): [ReadableStream<T>, ReadableStream<T>] {
@@ -236,7 +245,12 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
       }
       await writer.close();
     } catch (err) {
-      await writer.abort(err);
+      try {
+        await writer.abort(err);
+      } catch {
+        // Ignore abort failures; still surface the original write/close error.
+      }
+      throw err;
     }
   }
 

--- a/packages/node-fetch/tests/ReadableStream.spec.ts
+++ b/packages/node-fetch/tests/ReadableStream.spec.ts
@@ -128,4 +128,54 @@ pullCount: 3
       'startCount: 5',
     ]);
   });
+
+  it('values({ preventCancel: true }) does not destroy the stream on break', async () => {
+    const makeStream = () => {
+      let i = 0;
+      return new PonyfillReadableStream({
+        async pull(controller) {
+          await Promise.resolve();
+          if (i < 3) {
+            controller.enqueue(Buffer.from(String(i++)));
+          } else {
+            controller.close();
+          }
+        },
+      });
+    };
+
+    const keptOpen = makeStream();
+    const keptIterator = keptOpen.values({ preventCancel: true });
+    await keptIterator.next();
+    await keptIterator.return?.();
+    expect(keptOpen.readable.destroyed).toBe(false);
+
+    const rest: string[] = [];
+    for await (const chunk of keptOpen.values()) {
+      rest.push(Buffer.from(chunk as Buffer).toString('utf-8'));
+    }
+    expect(rest.length).toBeGreaterThan(0);
+
+    const cancelled = makeStream();
+    const cancelledIterator = cancelled.values();
+    await cancelledIterator.next();
+    await cancelledIterator.return?.();
+    expect(cancelled.readable.destroyed).toBe(true);
+  });
+
+  it('pipeTo rejects when the destination write fails', async () => {
+    const rs = new PonyfillReadableStream({
+      start(controller) {
+        controller.enqueue(Buffer.from('hi'));
+        controller.close();
+      },
+    });
+    const ws = new WritableStream({
+      write() {
+        throw new Error('write failed');
+      },
+    });
+
+    await expect(rs.pipeTo(ws)).rejects.toThrow('write failed');
+  });
 });

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -403,6 +403,12 @@ export function sendNodeResponse(
     serverResponse.once('close', () => {
       fetchBody.destroy();
     });
+    // Node's pipe() does not destroy the destination when the source errors (#3011)
+    fetchBody.once('error', err => {
+      if (!serverResponse.destroyed) {
+        serverResponse.destroy(err instanceof Error ? err : undefined);
+      }
+    });
     fetchBody.pipe(serverResponse, {
       end: true,
     });
@@ -434,7 +440,7 @@ function sendReadableStream(
     err => {
       // Body aborted/errored: destroy Node response so the client socket closes (RST)
       if (!serverResponse.destroyed) {
-        serverResponse.destroy(err);
+        serverResponse.destroy(err instanceof Error ? err : undefined);
       }
     },
   );

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -425,9 +425,19 @@ function sendReadableStream(
 ) {
   const reader = readableStream.getReader();
   nodeRequest?.once?.('error', err => {
-    reader.cancel(err);
+    // Ignore cancel() failures (e.g. stream already closed/errored)
+    reader.cancel(err).catch(() => {});
   });
-  return pumpToWritable(() => reader.read(), serverResponse);
+  return handleMaybePromise(
+    () => pumpToWritable(() => reader.read(), serverResponse),
+    () => {},
+    err => {
+      // Body aborted/errored: destroy Node response so the client socket closes (RST)
+      if (!serverResponse.destroyed) {
+        serverResponse.destroy(err);
+      }
+    },
+  );
 }
 
 export function isRequestInit(val: unknown): val is RequestInit {

--- a/packages/server/test/abort.spec.ts
+++ b/packages/server/test/abort.spec.ts
@@ -36,6 +36,68 @@ describe('Request Abort', () => {
           }),
         1000,
       );
+
+      skipIf(
+        (globalThis.Bun && serverImplName !== 'Bun') ||
+          (globalThis.Deno && serverImplName !== 'Deno'),
+      )(
+        'aborting response stream closes the socket',
+        () =>
+          new Promise<void>((resolve, reject) => {
+            const abortCtrl = new AbortController();
+            let pipeToError: any;
+            const adapter = createServerAdapter(() => {
+              const readable = new fetchAPI.ReadableStream({
+                async pull(controller) {
+                  await new Promise(resolve => setTimeout(resolve, 100));
+                  controller.enqueue(new Uint8Array([1, 2, 3, 4]));
+                },
+              });
+              const transform = new fetchAPI.TransformStream();
+              readable.pipeTo(transform.writable, { signal: abortCtrl.signal }).catch(err => {
+                pipeToError = err;
+              });
+              return new fetchAPI.Response(transform.readable);
+            });
+
+            server.addOnceHandler(adapter);
+
+            fetchAPI.fetch(server.url).then(
+              async response => {
+                const reader = response.body?.getReader();
+
+                if (!reader) {
+                  reject(new Error('No response body'));
+                  return;
+                }
+
+                // start reading the body
+                await reader.read();
+
+                // cancel the response
+                abortCtrl.abort();
+
+                try {
+                  while (true) {
+                    const { done } = await reader.read();
+                    if (done) break;
+                  }
+                  reject(new Error('Expected reader to be closed'));
+                } catch (err) {
+                  if (!pipeToError) {
+                    reject(new Error('Expected pipeTo to error'));
+                    return;
+                  }
+                  resolve();
+                }
+              },
+              err => {
+                reject(err);
+              },
+            );
+          }),
+        2000,
+      );
     });
   });
 });

--- a/packages/server/test/abort.spec.ts
+++ b/packages/server/test/abort.spec.ts
@@ -1,4 +1,7 @@
-import { describe, it } from '@jest/globals';
+import http from 'node:http';
+import https from 'node:https';
+import { describe, expect, it } from '@jest/globals';
+import { createDeferredPromise } from '@whatwg-node/promise-helpers';
 import { runTestsForEachFetchImpl } from './test-fetch';
 import { runTestsForEachServerImpl } from './test-server';
 
@@ -6,7 +9,7 @@ const skipIf = (condition: boolean) => (condition ? it.skip : it);
 
 describe('Request Abort', () => {
   runTestsForEachServerImpl((server, serverImplName) => {
-    runTestsForEachFetchImpl((_, { fetchAPI, createServerAdapter }) => {
+    runTestsForEachFetchImpl((implementationName, { fetchAPI, createServerAdapter }) => {
       skipIf(
         (globalThis.Bun && serverImplName !== 'Bun') ||
           (globalThis.Deno && serverImplName !== 'Deno'),
@@ -37,66 +40,103 @@ describe('Request Abort', () => {
         1000,
       );
 
+      // #3011: aborting/erroring the response body must destroy the Node response and
+      // close the socket (client sees RST / ECONNRESET). Exercise via raw node:http(s)
+      // so we assert the socket, not fetch-client stream quirks. Skip libcurl/uWS.
       skipIf(
-        (globalThis.Bun && serverImplName !== 'Bun') ||
+        implementationName === 'libcurl' ||
+          serverImplName === 'uWebSockets' ||
+          serverImplName === 'Bun' ||
+          serverImplName === 'Deno' ||
+          (globalThis.Bun && serverImplName !== 'Bun') ||
           (globalThis.Deno && serverImplName !== 'Deno'),
       )(
         'aborting response stream closes the socket',
-        () =>
-          new Promise<void>((resolve, reject) => {
-            const abortCtrl = new AbortController();
-            let pipeToError: any;
+        async () => {
+          const unexpectedLogs: string[] = [];
+          const originalConsoleError = console.error;
+          console.error = (...args: unknown[]) => {
+            unexpectedLogs.push(args.map(String).join(' '));
+          };
+
+          const abortCtrl = new AbortController();
+          const pipeToErrored$ = createDeferredPromise<void>();
+
+          try {
             const adapter = createServerAdapter(() => {
               const readable = new fetchAPI.ReadableStream({
                 async pull(controller) {
-                  await new Promise(resolve => setTimeout(resolve, 100));
+                  await new Promise(resolve => setTimeout(resolve, 50));
                   controller.enqueue(new Uint8Array([1, 2, 3, 4]));
                 },
               });
               const transform = new fetchAPI.TransformStream();
-              readable.pipeTo(transform.writable, { signal: abortCtrl.signal }).catch(err => {
-                pipeToError = err;
+              readable.pipeTo(transform.writable, { signal: abortCtrl.signal }).catch(() => {
+                pipeToErrored$.resolve();
               });
               return new fetchAPI.Response(transform.readable);
             });
 
-            server.addOnceHandler(adapter);
+            await server.addOnceHandler(adapter);
 
-            fetchAPI.fetch(server.url).then(
-              async response => {
-                const reader = response.body?.getReader();
+            const url = new URL(server.url);
+            const transport = url.protocol === 'https:' ? https : http;
 
-                if (!reader) {
-                  reject(new Error('No response body'));
+            await new Promise<void>((resolve, reject) => {
+              const timeout = setTimeout(
+                () => reject(new Error('socket did not close after response body abort')),
+                2000,
+              );
+
+              const settle = () => {
+                clearTimeout(timeout);
+                resolve();
+              };
+
+              const req = transport.get(
+                {
+                  hostname: url.hostname,
+                  port: url.port,
+                  path: url.pathname + url.search,
+                  // ephemeral test CA is already in tls default store for node:https
+                  rejectUnauthorized: url.protocol === 'https:' ? true : undefined,
+                },
+                res => {
+                  res.once('data', () => {
+                    // Abort the *response body* stream after bytes have started flowing
+                    abortCtrl.abort();
+                  });
+                  // After destroy(), Node should RST / prematurely close the connection
+                  res.on('aborted', settle);
+                  res.on('error', settle);
+                  res.on('close', settle);
+                  res.on('end', settle);
+                },
+              );
+
+              req.on('error', (err: NodeJS.ErrnoException) => {
+                if (err.code === 'ECONNRESET' || err.code === 'ECONNABORTED') {
+                  settle();
                   return;
                 }
-
-                // start reading the body
-                await reader.read();
-
-                // cancel the response
-                abortCtrl.abort();
-
-                try {
-                  while (true) {
-                    const { done } = await reader.read();
-                    if (done) break;
-                  }
-                  reject(new Error('Expected reader to be closed'));
-                } catch (err) {
-                  if (!pipeToError) {
-                    reject(new Error('Expected pipeTo to error'));
-                    return;
-                  }
-                  resolve();
-                }
-              },
-              err => {
+                clearTimeout(timeout);
                 reject(err);
-              },
-            );
-          }),
-        2000,
+              });
+            });
+
+            await pipeToErrored$.promise;
+
+            expect(
+              unexpectedLogs.some(log => log.includes('Unexpected error while handling request')),
+            ).toBe(false);
+          } finally {
+            console.error = originalConsoleError;
+            if (!abortCtrl.signal.aborted) {
+              abortCtrl.abort();
+            }
+          }
+        },
+        4000,
       );
     });
   });

--- a/packages/server/test/abort.spec.ts
+++ b/packages/server/test/abort.spec.ts
@@ -40,9 +40,9 @@ describe('Request Abort', () => {
         1000,
       );
 
-      // #3011: aborting/erroring the response body must destroy the Node response and
-      // close the socket (client sees RST / ECONNRESET). Exercise via raw node:http(s)
-      // so we assert the socket, not fetch-client stream quirks. Skip libcurl/uWS.
+      // #3011: error/abort on the response body must destroy the Node response and
+      // close the socket (client sees RST / ECONNRESET). Use raw node:http(s) so we
+      // assert the socket itself. Skip libcurl/uWS/Bun/Deno (different write paths).
       skipIf(
         implementationName === 'libcurl' ||
           serverImplName === 'uWebSockets' ||
@@ -60,21 +60,33 @@ describe('Request Abort', () => {
           };
 
           const abortCtrl = new AbortController();
-          const pipeToErrored$ = createDeferredPromise<void>();
+          const bodyErrored$ = createDeferredPromise<void>();
 
           try {
             const adapter = createServerAdapter(() => {
-              const readable = new fetchAPI.ReadableStream({
+              let streamController: ReadableStreamDefaultController<Uint8Array>;
+              const body = new fetchAPI.ReadableStream<Uint8Array>({
+                start(controller) {
+                  streamController = controller;
+                  abortCtrl.signal.addEventListener(
+                    'abort',
+                    () => {
+                      streamController.error(
+                        abortCtrl.signal.reason instanceof Error
+                          ? abortCtrl.signal.reason
+                          : new Error('response body aborted'),
+                      );
+                      bodyErrored$.resolve();
+                    },
+                    { once: true },
+                  );
+                },
                 async pull(controller) {
                   await new Promise(resolve => setTimeout(resolve, 50));
                   controller.enqueue(new Uint8Array([1, 2, 3, 4]));
                 },
               });
-              const transform = new fetchAPI.TransformStream();
-              readable.pipeTo(transform.writable, { signal: abortCtrl.signal }).catch(() => {
-                pipeToErrored$.resolve();
-              });
-              return new fetchAPI.Response(transform.readable);
+              return new fetchAPI.Response(body);
             });
 
             await server.addOnceHandler(adapter);
@@ -98,19 +110,25 @@ describe('Request Abort', () => {
                   hostname: url.hostname,
                   port: url.port,
                   path: url.pathname + url.search,
-                  // ephemeral test CA is already in tls default store for node:https
-                  rejectUnauthorized: url.protocol === 'https:' ? true : undefined,
                 },
                 res => {
                   res.once('data', () => {
-                    // Abort the *response body* stream after bytes have started flowing
+                    // Abort/error the response body after bytes have started flowing
                     abortCtrl.abort();
                   });
-                  // After destroy(), Node should RST / prematurely close the connection
+                  // After destroy(), Node should RST / prematurely close the connection.
+                  // Do not treat a normal completed response (end / complete close) as success.
                   res.on('aborted', settle);
                   res.on('error', settle);
-                  res.on('close', settle);
-                  res.on('end', settle);
+                  res.on('close', () => {
+                    if (!res.complete) {
+                      settle();
+                    }
+                  });
+                  res.on('end', () => {
+                    clearTimeout(timeout);
+                    reject(new Error('response ended cleanly; expected socket abort/reset'));
+                  });
                 },
               );
 
@@ -124,7 +142,7 @@ describe('Request Abort', () => {
               });
             });
 
-            await pipeToErrored$.promise;
+            await bodyErrored$.promise;
 
             expect(
               unexpectedLogs.some(log => log.includes('Unexpected error while handling request')),


### PR DESCRIPTION
## Summary
- When a response body stream errors/aborts, destroy the Node `ServerResponse` so the client socket closes (RST / ECONNRESET) instead of hanging. Covers both the WHATWG reader pump path and the ponyfill `.pipe()` path; also propagates `Readable.destroy(err)` in `@whatwg-node/node-fetch` when there is no `cancel` hook.
- Ponyfill `ReadableStream.pipeTo()` now rejects when the destination write fails (after aborting the writer), instead of resolving successfully.
- Honors `values({ preventCancel: true })` via Node `destroyOnReturn: false`.

Fixes #3011
Fixes #3003

## Test plan
- [x] `aborting response stream closes the socket` (raw http(s) client, incomplete close)
- [x] `pipeTo rejects when the destination write fails`
- [x] `values({ preventCancel: true })` regression