### PR TITLE
server is a peer dependency to server cookies plugin

### DIFF
--- a/.changeset/@whatwg-node_server-plugin-cookies-3402-dependencies.md
+++ b/.changeset/@whatwg-node_server-plugin-cookies-3402-dependencies.md
@@ -3,4 +3,4 @@
 ---
 dependencies updates:
   - Removed dependency [`@whatwg-node/server@^0.11.0` ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.11.0) (from `dependencies`)
-  - Added dependency [`@whatwg-node/server@^0.10.0 | ^0.11.0` ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.10.0) (to `peerDependencies`)
+  - Added dependency [`@whatwg-node/server@^0.10.0 || ^0.11.0` ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.10.0) (to `peerDependencies`)

--- a/.changeset/@whatwg-node_server-plugin-cookies-3402-dependencies.md
+++ b/.changeset/@whatwg-node_server-plugin-cookies-3402-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@whatwg-node/server-plugin-cookies": patch
+---
+dependencies updates:
+  - Removed dependency [`@whatwg-node/server@^0.11.0` ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.11.0) (from `dependencies`)
+  - Added dependency [`@whatwg-node/server@^0.10.0 | ^0.11.0` ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.10.0) (to `peerDependencies`)

--- a/.changeset/yellow-falcons-happen.md
+++ b/.changeset/yellow-falcons-happen.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/server-plugin-cookies': patch
+---
+
+@whatwg-node/server is a peer dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -22475,8 +22475,10 @@
       "license": "MIT",
       "dependencies": {
         "@whatwg-node/cookie-store": "^0.2.2",
-        "@whatwg-node/server": "^0.11.0",
         "tslib": "^2.6.3"
+      },
+      "devDependencies": {
+        "@whatwg-node/server": "^0.11.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -22489,6 +22491,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.11.0.tgz",
       "integrity": "sha512-VSdkwnJRr8Yv9UgB2aXB3VUPWwd6Oqnn0hycFwhg9pZgWxJXb7JmhsiXe9tmpMwjHFxli12PGcz9aI63YYloGQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@envelop/instrumentation": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22481,6 +22481,22 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "packages/server-plugin-cookies/node_modules/@whatwg-node/server": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.11.0.tgz",
+      "integrity": "sha512-VSdkwnJRr8Yv9UgB2aXB3VUPWwd6Oqnn0hycFwhg9pZgWxJXb7JmhsiXe9tmpMwjHFxli12PGcz9aI63YYloGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@envelop/instrumentation": "^1.0.0",
+        "@whatwg-node/disposablestack": "^0.0.6",
+        "@whatwg-node/fetch": "^0.10.13",
+        "@whatwg-node/promise-helpers": "^1.3.2",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22484,7 +22484,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@whatwg-node/server": "^0.10.0 | ^0.11.0"
+        "@whatwg-node/server": "^0.10.0 || ^0.11.0"
       }
     },
     "packages/server-plugin-cookies/node_modules/@whatwg-node/server": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22480,6 +22480,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@whatwg-node/server": "^0.10.0 | ^0.11.0"
       }
     },
     "packages/server-plugin-cookies/node_modules/@whatwg-node/server": {

--- a/packages/server-plugin-cookies/package.json
+++ b/packages/server-plugin-cookies/package.json
@@ -33,6 +33,9 @@
     "./package.json": "./package.json"
   },
   "typings": "dist/typings/index.d.ts",
+  "peerDependencies": {
+    "@whatwg-node/server": "^0.10.0 | ^0.11.0"
+  },
   "dependencies": {
     "@whatwg-node/cookie-store": "^0.2.2",
     "@whatwg-node/server": "^0.11.0",

--- a/packages/server-plugin-cookies/package.json
+++ b/packages/server-plugin-cookies/package.json
@@ -38,8 +38,10 @@
   },
   "dependencies": {
     "@whatwg-node/cookie-store": "^0.2.2",
-    "@whatwg-node/server": "^0.11.0",
     "tslib": "^2.6.3"
+  },
+  "devDependencies": {
+    "@whatwg-node/server": "^0.11.0"
   },
   "publishConfig": {
     "directory": "dist",

--- a/packages/server-plugin-cookies/package.json
+++ b/packages/server-plugin-cookies/package.json
@@ -34,7 +34,7 @@
   },
   "typings": "dist/typings/index.d.ts",
   "peerDependencies": {
-    "@whatwg-node/server": "^0.10.0 | ^0.11.0"
+    "@whatwg-node/server": "^0.10.0 || ^0.11.0"
   },
   "dependencies": {
     "@whatwg-node/cookie-store": "^0.2.2",


### PR DESCRIPTION
Not a breaking change because npm will install peer deps, and so will most package managers. Even if they dont, you can only use this plugin with whatwg node server.