### PR TITLE
fix(ci): npm 12 only on supported Node + uws https

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@v1
         with:
-          install-command: corepack npm install
+          install-command: bash scripts/ci-npm-install.sh
           node-version-file: .node-version
       - name: Build Packages
         run: npm run build
@@ -72,7 +72,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@v1
         with:
-          install-command: corepack npm install
+          install-command: bash scripts/ci-npm-install.sh
           node-version-file: .node-version
       - name: Setup K6
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@v1
         with:
-          install-command: corepack npm install
+          install-command: bash scripts/ci-npm-install.sh
           node-version-file: .node-version
       - name: Prettier Check
         run: npm run prettier:check
@@ -40,7 +40,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@v1
         with:
-          install-command: corepack npm install
+          install-command: bash scripts/ci-npm-install.sh
           node-version-file: .node-version
       - name: ESLint
         run: npm run lint
@@ -54,7 +54,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@v1
         with:
-          install-command: corepack npm install
+          install-command: bash scripts/ci-npm-install.sh
           node-version-file: .node-version
       - name: Type Check
         run: npm run ts:check
@@ -79,7 +79,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@v1
         with:
-          install-command: corepack npm install
+          install-command: bash scripts/ci-npm-install.sh
           node-version: ${{ matrix.node-version }}
       - name: Cache npm and Jest
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -120,7 +120,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@v1
         with:
-          install-command: corepack npm install
+          install-command: bash scripts/ci-npm-install.sh
           node-version-file: .node-version
       - name: Test
         run: npm run test:bun
@@ -139,7 +139,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@v1
         with:
-          install-command: corepack npm install
+          install-command: bash scripts/ci-npm-install.sh
           node-version-file: .node-version
       - name: Test
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
@@ -157,7 +157,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@v1
         with:
-          install-command: corepack npm install
+          install-command: bash scripts/ci-npm-install.sh
           node-version-file: .node-version
       - name: Build Packages
         run: npm run build
@@ -201,7 +201,7 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@v1
         with:
-          install-command: corepack npm install
+          install-command: bash scripts/ci-npm-install.sh
           node-version-file: .node-version
 
       - name: Build Packages

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 min-release-age=3
 provenance=true
 force=true
+allow-git=root

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
         "e2e/*",
         "benchmarks/*"
       ],
-      "dependencies": {
-        "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js.git#v20.69.0"
-      },
       "devDependencies": {
         "@babel/core": "7.29.7",
         "@babel/plugin-transform-class-properties": "7.29.7",
@@ -22934,6 +22931,12 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uWebSockets.js": {
+      "version": "20.69.0",
+      "resolved": "git+https://github.com/uNetworking/uWebSockets.js.git#dddd8ffd1b2c28a66022160923ca92f064cdacb4",
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -23744,12 +23747,6 @@
       "peerDependencies": {
         "@whatwg-node/server": "^0.10.0 || ^0.11.0"
       }
-    },
-    "node_modules/uWebSockets.js": {
-      "version": "20.69.0",
-      "resolved": "git+https://github.com/uNetworking/uWebSockets.js.git#dddd8ffd1b2c28a66022160923ca92f064cdacb4",
-      "license": "Apache-2.0",
-      "optional": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "e2e/*",
         "benchmarks/*"
       ],
+      "dependencies": {
+        "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js.git#v20.69.0"
+      },
       "devDependencies": {
         "@babel/core": "7.29.7",
         "@babel/plugin-transform-class-properties": "7.29.7",
@@ -59,7 +62,7 @@
       },
       "optionalDependencies": {
         "node-libcurl": "4.1.0",
-        "uWebSockets.js": "uNetworking/uWebSockets.js#v20.69.0"
+        "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js.git#v20.69.0"
       }
     },
     "benchmarks/node-fetch": {
@@ -22931,12 +22934,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/uWebSockets.js": {
-      "version": "20.69.0",
-      "resolved": "git+ssh://git@github.com/uNetworking/uWebSockets.js.git#dddd8ffd1b2c28a66022160923ca92f064cdacb4",
-      "license": "Apache-2.0",
-      "optional": true
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -23747,6 +23744,12 @@
       "peerDependencies": {
         "@whatwg-node/server": "^0.10.0 || ^0.11.0"
       }
+    },
+    "node_modules/uWebSockets.js": {
+      "version": "20.69.0",
+      "resolved": "git+https://github.com/uNetworking/uWebSockets.js.git#dddd8ffd1b2c28a66022160923ca92f064cdacb4",
+      "license": "Apache-2.0",
+      "optional": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "optionalDependencies": {
     "node-libcurl": "4.1.0",
-    "uWebSockets.js": "uNetworking/uWebSockets.js#v20.69.0"
+    "uWebSockets.js": "https://github.com/uNetworking/uWebSockets.js.git#v20.69.0"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   "devEngines": {
     "packageManager": {
       "name": "npm",
-      "version": "^12.0.2"
+      "version": ">=10.8.2"
     }
   },
   "lint-staged": {

--- a/scripts/ci-npm-install.sh
+++ b/scripts/ci-npm-install.sh
@@ -23,9 +23,9 @@ if [[ "$use_corepack_npm" -eq 1 ]]; then
   package_manager="$(node -p "require('./package.json').packageManager")"
   echo "Activating ${package_manager} via corepack (Node ${node_major}.${node_minor}.${node_patch})"
   # shared-config runs `corepack enable` before setup-node; setup-node then
-  # reinstalls Node's bundled npm. Re-enable/activate so later `npm run …`
-  # steps also use packageManager and stop emitting EBADDEVENGINES.
-  corepack enable
+  # reinstalls Node's bundled npm. Re-enable the npm shim and activate
+  # packageManager so later bare `npm run …` steps use that version.
+  corepack enable npm
   corepack prepare "${package_manager}" --activate
   hash -r
   echo "npm $(npm --version)"

--- a/scripts/ci-npm-install.sh
+++ b/scripts/ci-npm-install.sh
@@ -1,36 +1,52 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# npm@12 (packageManager) only supports Node ^22.22.2 || ^24.15.0 || >=26.
+# Pick a Corepack-managed npm that matches this Node's engines, instead of
+# relying on whatever bundled npm setup-node left on PATH.
+#
+# npm@12: ^22.22.2 || ^24.15.0 || >=26
+# npm@11: ^20.17.0 || >=22.9.0
+# npm@10: ^18.17.0 || >=20.5.0
+
 node_major="$(node -p "process.versions.node.split('.')[0]")"
 node_minor="$(node -p "process.versions.node.split('.')[1]")"
 node_patch="$(node -p "process.versions.node.split('.')[2]")"
 
-use_corepack_npm=0
+package_manager="$(node -p "require('./package.json').packageManager")"
+
+supports_npm12=0
 if [[ "$node_major" -ge 26 ]]; then
-  use_corepack_npm=1
+  supports_npm12=1
 elif [[ "$node_major" -eq 24 && "$node_minor" -ge 15 ]]; then
-  # ^24.15.0
-  use_corepack_npm=1
+  supports_npm12=1
 elif [[ "$node_major" -eq 22 ]]; then
   if [[ "$node_minor" -gt 22 ]] || { [[ "$node_minor" -eq 22 ]] && [[ "$node_patch" -ge 2 ]]; }; then
-    # ^22.22.2
-    use_corepack_npm=1
+    supports_npm12=1
   fi
 fi
 
-if [[ "$use_corepack_npm" -eq 1 ]]; then
-  package_manager="$(node -p "require('./package.json').packageManager")"
-  echo "Activating ${package_manager} via corepack (Node ${node_major}.${node_minor}.${node_patch})"
-  # shared-config runs `corepack enable` before setup-node; setup-node then
-  # reinstalls Node's bundled npm. Re-enable the npm shim and activate
-  # packageManager so later bare `npm run …` steps use that version.
-  corepack enable npm
-  corepack prepare "${package_manager}" --activate
-  hash -r
-  echo "npm $(npm --version)"
-  exec npm install
+supports_npm11=0
+if [[ "$node_major" -gt 22 ]] || { [[ "$node_major" -eq 22 ]] && [[ "$node_minor" -ge 9 ]]; }; then
+  supports_npm11=1
+elif [[ "$node_major" -eq 20 && "$node_minor" -ge 17 ]]; then
+  # ^20.17.0
+  supports_npm11=1
 fi
 
-echo "Using bundled npm $(npm --version) (Node ${node_major}.${node_minor}.${node_patch} is below npm@12 engine range)"
+if [[ "$supports_npm12" -eq 1 ]]; then
+  selected_npm="$package_manager"
+elif [[ "$supports_npm11" -eq 1 ]]; then
+  selected_npm="npm@11.19.0"
+else
+  selected_npm="npm@10.9.2"
+fi
+
+echo "Activating ${selected_npm} via corepack (Node ${node_major}.${node_minor}.${node_patch})"
+# shared-config runs `corepack enable` before setup-node; setup-node then
+# reinstalls Node's bundled npm. Explicitly enable the npm shim and activate
+# a Node-compatible npm so later bare `npm run …` steps use it.
+corepack enable npm
+corepack prepare "${selected_npm}" --activate
+hash -r
+echo "npm $(npm --version)"
 exec npm install

--- a/scripts/ci-npm-install.sh
+++ b/scripts/ci-npm-install.sh
@@ -1,52 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Pick a Corepack-managed npm that matches this Node's engines, instead of
-# relying on whatever bundled npm setup-node left on PATH.
-#
-# npm@12: ^22.22.2 || ^24.15.0 || >=26
-# npm@11: ^20.17.0 || >=22.9.0
-# npm@10: ^18.17.0 || >=20.5.0
-
+# npm@12 (packageManager) only supports Node ^22.22.2 || ^24.15.0 || >=26.
 node_major="$(node -p "process.versions.node.split('.')[0]")"
 node_minor="$(node -p "process.versions.node.split('.')[1]")"
 node_patch="$(node -p "process.versions.node.split('.')[2]")"
 
-package_manager="$(node -p "require('./package.json').packageManager")"
-
-supports_npm12=0
+use_corepack_npm=0
 if [[ "$node_major" -ge 26 ]]; then
-  supports_npm12=1
+  use_corepack_npm=1
 elif [[ "$node_major" -eq 24 && "$node_minor" -ge 15 ]]; then
-  supports_npm12=1
+  # ^24.15.0
+  use_corepack_npm=1
 elif [[ "$node_major" -eq 22 ]]; then
   if [[ "$node_minor" -gt 22 ]] || { [[ "$node_minor" -eq 22 ]] && [[ "$node_patch" -ge 2 ]]; }; then
-    supports_npm12=1
+    # ^22.22.2
+    use_corepack_npm=1
   fi
 fi
 
-supports_npm11=0
-if [[ "$node_major" -gt 22 ]] || { [[ "$node_major" -eq 22 ]] && [[ "$node_minor" -ge 9 ]]; }; then
-  supports_npm11=1
-elif [[ "$node_major" -eq 20 && "$node_minor" -ge 17 ]]; then
-  # ^20.17.0
-  supports_npm11=1
+if [[ "$use_corepack_npm" -eq 1 ]]; then
+  package_manager="$(node -p "require('./package.json').packageManager")"
+  echo "Activating ${package_manager} via corepack (Node ${node_major}.${node_minor}.${node_patch})"
+  # shared-config runs `corepack enable` before setup-node; setup-node then
+  # reinstalls Node's bundled npm. Re-enable the npm shim and activate
+  # packageManager so later bare `npm run …` steps use that version.
+  corepack enable npm
+  corepack prepare "${package_manager}" --activate
+  hash -r
+  echo "npm $(npm --version)"
+  exec npm install
 fi
 
-if [[ "$supports_npm12" -eq 1 ]]; then
-  selected_npm="$package_manager"
-elif [[ "$supports_npm11" -eq 1 ]]; then
-  selected_npm="npm@11.19.0"
-else
-  selected_npm="npm@10.9.2"
-fi
-
-echo "Activating ${selected_npm} via corepack (Node ${node_major}.${node_minor}.${node_patch})"
-# shared-config runs `corepack enable` before setup-node; setup-node then
-# reinstalls Node's bundled npm. Explicitly enable the npm shim and activate
-# a Node-compatible npm so later bare `npm run …` steps use it.
-corepack enable npm
-corepack prepare "${selected_npm}" --activate
-hash -r
-echo "npm $(npm --version)"
+echo "Using bundled npm $(npm --version) (Node ${node_major}.${node_minor}.${node_patch} is below npm@12 engine range)"
 exec npm install

--- a/scripts/ci-npm-install.sh
+++ b/scripts/ci-npm-install.sh
@@ -4,19 +4,24 @@ set -euo pipefail
 # npm@12 (packageManager) only supports Node ^22.22.2 || ^24.15.0 || >=26.
 node_major="$(node -p "process.versions.node.split('.')[0]")"
 node_minor="$(node -p "process.versions.node.split('.')[1]")"
+node_patch="$(node -p "process.versions.node.split('.')[2]")"
 
 use_corepack_npm=0
 if [[ "$node_major" -ge 26 ]]; then
   use_corepack_npm=1
 elif [[ "$node_major" -eq 24 && "$node_minor" -ge 15 ]]; then
+  # ^24.15.0
   use_corepack_npm=1
-elif [[ "$node_major" -eq 22 && "$node_minor" -ge 22 ]]; then
-  use_corepack_npm=1
+elif [[ "$node_major" -eq 22 ]]; then
+  if [[ "$node_minor" -gt 22 ]] || { [[ "$node_minor" -eq 22 ]] && [[ "$node_patch" -ge 2 ]]; }; then
+    # ^22.22.2
+    use_corepack_npm=1
+  fi
 fi
 
 if [[ "$use_corepack_npm" -eq 1 ]]; then
   package_manager="$(node -p "require('./package.json').packageManager")"
-  echo "Activating ${package_manager} via corepack (Node ${node_major}.${node_minor})"
+  echo "Activating ${package_manager} via corepack (Node ${node_major}.${node_minor}.${node_patch})"
   # shared-config runs `corepack enable` before setup-node; setup-node then
   # reinstalls Node's bundled npm. Re-enable/activate so later `npm run …`
   # steps also use packageManager and stop emitting EBADDEVENGINES.
@@ -27,5 +32,5 @@ if [[ "$use_corepack_npm" -eq 1 ]]; then
   exec npm install
 fi
 
-echo "Using bundled npm $(npm --version) (Node ${node_major}.${node_minor} is below npm@12 engine range)"
+echo "Using bundled npm $(npm --version) (Node ${node_major}.${node_minor}.${node_patch} is below npm@12 engine range)"
 exec npm install

--- a/scripts/ci-npm-install.sh
+++ b/scripts/ci-npm-install.sh
@@ -15,9 +15,17 @@ elif [[ "$node_major" -eq 22 && "$node_minor" -ge 22 ]]; then
 fi
 
 if [[ "$use_corepack_npm" -eq 1 ]]; then
-  echo "Using corepack npm (Node ${node_major}.${node_minor})"
-  exec corepack npm install
+  package_manager="$(node -p "require('./package.json').packageManager")"
+  echo "Activating ${package_manager} via corepack (Node ${node_major}.${node_minor})"
+  # shared-config runs `corepack enable` before setup-node; setup-node then
+  # reinstalls Node's bundled npm. Re-enable/activate so later `npm run …`
+  # steps also use packageManager and stop emitting EBADDEVENGINES.
+  corepack enable
+  corepack prepare "${package_manager}" --activate
+  hash -r
+  echo "npm $(npm --version)"
+  exec npm install
 fi
 
-echo "Using bundled npm (Node ${node_major}.${node_minor} is below npm@12 engine range)"
+echo "Using bundled npm $(npm --version) (Node ${node_major}.${node_minor} is below npm@12 engine range)"
 exec npm install

--- a/scripts/ci-npm-install.sh
+++ b/scripts/ci-npm-install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# npm@12 (packageManager) only supports Node ^22.22.2 || ^24.15.0 || >=26.
+node_major="$(node -p "process.versions.node.split('.')[0]")"
+node_minor="$(node -p "process.versions.node.split('.')[1]")"
+
+use_corepack_npm=0
+if [[ "$node_major" -ge 26 ]]; then
+  use_corepack_npm=1
+elif [[ "$node_major" -eq 24 && "$node_minor" -ge 15 ]]; then
+  use_corepack_npm=1
+elif [[ "$node_major" -eq 22 && "$node_minor" -ge 22 ]]; then
+  use_corepack_npm=1
+fi
+
+if [[ "$use_corepack_npm" -eq 1 ]]; then
+  echo "Using corepack npm (Node ${node_major}.${node_minor})"
+  exec corepack npm install
+fi
+
+echo "Using bundled npm (Node ${node_major}.${node_minor} is below npm@12 engine range)"
+exec npm install


### PR DESCRIPTION
## Summary
- `corepack npm install` (npm@12) fails on Node 18/20 (`ERR_REQUIRE_ESM` / unsupported engine). CI now uses `scripts/ci-npm-install.sh` to pick corepack npm only when Node is in npm@12’s range (`^22.22.2 || ^24.15.0 || >=26`), otherwise bundled npm.
- npm@12 defaults `allow-git=none`, which silently skipped optional `uWebSockets.js`. Set `allow-git=root` and keep the dep on `git+https`.

## Test plan
- [ ] `unit / node 18` and `unit / node 20` install + tests pass
- [ ] Jobs on Node 26 still use corepack npm@12
- [ ] `type check` / `esm` / e2e find `uWebSockets.js` types again