### PR TITLE
feat!: drop Node.js 18 and 20, require >=22.15

### DIFF
--- a/.changeset/drop-node-18-20.md
+++ b/.changeset/drop-node-18-20.md
@@ -1,0 +1,13 @@
+---
+'@whatwg-node/server': minor
+'@whatwg-node/fetch': minor
+'@whatwg-node/node-fetch': minor
+'@whatwg-node/events': minor
+'@whatwg-node/cookie-store': minor
+'@whatwg-node/server-plugin-cookies': minor
+'@whatwg-node/disposablestack': minor
+'fetchache': minor
+'@whatwg-node/promise-helpers': minor
+---
+
+Drop support for Node.js 18 and 20. The minimum supported Node.js version is now 22.15.

--- a/.changeset/drop-node-18-20.md
+++ b/.changeset/drop-node-18-20.md
@@ -10,4 +10,19 @@
 '@whatwg-node/promise-helpers': minor
 ---
 
-Drop support for Node.js 18 and 20. The minimum supported Node.js version is now 22.15.
+Drop support for Node.js 18 and 20. The minimum supported Node.js version is now **22.15**.
+
+### Why
+
+Node.js 18 and 20 are end-of-life and no longer receive security updates. Keeping them in our support matrix forced version-specific workarounds and slowed adoption of newer Node TLS APIs.
+
+The floor is set to **22.15** (not just 22.0) so we can rely on `tls.getCACertificates()`, which landed in Node.js 22.15 / 23.10. That matches the oldest currently supported LTS line (22 Maintenance) while dropping only EOL majors.
+
+### What changed
+
+- **`engines.node`**: all published packages now declare `>=22.15.0` (including `@whatwg-node/promise-helpers`, which was still on `>=16`).
+- **`@whatwg-node/server`**: removed the Node 18 `setHeaders` workaround (`isNode1x`); `ServerResponse#setHeaders` is used whenever it exists.
+- **`@whatwg-node/node-fetch`**: libcurl always loads CAs from `tls.getCACertificates('default')`. The old `NODE_EXTRA_CA_CERTS` / `tls.rootCertificates` fallback path for engines below 22.15 is gone.
+- **CI / e2e**: unit matrix is `[22, 24, 26]`; AWS Lambda runtime and Azure Function target moved from Node 20 to Node 22.
+
+If you are still on Node 18 or 20, upgrade to Node.js **22.15+** (or 24 / 26) before installing this release.

--- a/.changeset/drop-node-18-20.md
+++ b/.changeset/drop-node-18-20.md
@@ -4,10 +4,10 @@
 '@whatwg-node/node-fetch': minor
 '@whatwg-node/events': minor
 '@whatwg-node/cookie-store': minor
-'@whatwg-node/server-plugin-cookies': minor
+'@whatwg-node/server-plugin-cookies': major
 '@whatwg-node/disposablestack': minor
 'fetchache': minor
-'@whatwg-node/promise-helpers': minor
+'@whatwg-node/promise-helpers': major
 ---
 
 Drop support for Node.js 18 and 20. The minimum supported Node.js version is now **22.15**.
@@ -17,6 +17,11 @@ Drop support for Node.js 18 and 20. The minimum supported Node.js version is now
 Node.js 18 and 20 are end-of-life and no longer receive security updates. Keeping them in our support matrix forced version-specific workarounds and slowed adoption of newer Node TLS APIs.
 
 The floor is set to **22.15** (not just 22.0) so we can rely on `tls.getCACertificates()`, which landed in Node.js 22.15 / 23.10. That matches the oldest currently supported LTS line (22 Maintenance) while dropping only EOL majors.
+
+### SemVer
+
+- **0.x packages**: minor bump (breaking changes are allowed in minors while major is 0).
+- **1.x packages** (`@whatwg-node/promise-helpers`, `@whatwg-node/server-plugin-cookies`): **major** bump, since dropping supported Node versions is a breaking engines change for SemVer `>=1.0.0` consumers.
 
 ### What changed
 

--- a/.changeset/libcurl-default-ca-store.md
+++ b/.changeset/libcurl-default-ca-store.md
@@ -4,8 +4,6 @@
 
 Align libcurl TLS trust with Node's default CA store.
 
-When `tls.getCACertificates` is available (Node.js 22.15+ / 23.10+), the libcurl fetch implementation now loads CAs from `tls.getCACertificates('default')` instead of only reading `NODE_EXTRA_CA_CERTS` / `tls.rootCertificates`. That means custom CAs installed with `tls.setDefaultCACertificates(...)`, plus CAs from `NODE_EXTRA_CA_CERTS` when it was set **before** process start, are honored the same way as Node's built-in `https` client.
-
-On older Node versions (engines still allow `>=18`), behavior is unchanged: `NODE_EXTRA_CA_CERTS` still maps to libcurl `CAINFO`, otherwise the bundled Mozilla roots are used.
+The libcurl fetch implementation now loads CAs from `tls.getCACertificates('default')` instead of only reading `NODE_EXTRA_CA_CERTS` / `tls.rootCertificates`. That means custom CAs installed with `tls.setDefaultCACertificates(...)`, plus CAs from `NODE_EXTRA_CA_CERTS` when it was set **before** process start, are honored the same way as Node's built-in `https` client.
 
 If you previously set `NODE_EXTRA_CA_CERTS` at runtime after the process started, prefer `tls.setDefaultCACertificates([...tls.getCACertificates('default'), ...yourCerts])` so both Node TLS and libcurl pick up the same store. That setter requires Node.js 22.19+ / 24.5+ (guard with `typeof tls.setDefaultCACertificates === 'function'` on older versions).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,7 @@ jobs:
           - 8888:80
     strategy:
       matrix:
-        node-version: [18, 20, 24, 26]
+        node-version: [22, 24, 26]
       fail-fast: false
     steps:
       - name: Checkout Master

--- a/e2e/aws-lambda/scripts/createAwsLambdaDeployment.ts
+++ b/e2e/aws-lambda/scripts/createAwsLambdaDeployment.ts
@@ -68,7 +68,7 @@ export function createAwsLambdaDeployment(): DeploymentConfiguration<{
         'func',
         {
           role: lambdaRole.arn,
-          runtime: 'nodejs20.x',
+          runtime: 'nodejs22.x',
           handler: 'index.handler',
           code: new pulumi.asset.AssetArchive({
             'index.js': new pulumi.asset.FileAsset(join(__dirname, '../dist/index.js')),

--- a/e2e/azure-function/scripts/bundle.js
+++ b/e2e/azure-function/scripts/bundle.js
@@ -13,7 +13,7 @@ async function main() {
     minify: false,
     bundle: true,
     platform: 'node',
-    target: 'node20',
+    target: 'node22',
     external: ['@azure/functions-core'],
   });
 

--- a/e2e/azure-function/scripts/createAzureFunctionDeployment.ts
+++ b/e2e/azure-function/scripts/createAzureFunctionDeployment.ts
@@ -156,7 +156,7 @@ export function createAzureFunctionDeployment(): DeploymentConfiguration<{
             ],
             http20Enabled: true,
             httpLoggingEnabled: true,
-            linuxFxVersion: 'node|20',
+            linuxFxVersion: 'node|22',
           },
         },
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22029,7 +22029,7 @@
         "tslib": "^2.6.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.15.0"
       }
     },
     "packages/disposablestack": {
@@ -22041,7 +22041,7 @@
         "tslib": "^2.6.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.15.0"
       }
     },
     "packages/events": {
@@ -22052,7 +22052,7 @@
         "tslib": "^2.6.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.15.0"
       }
     },
     "packages/fetch": {
@@ -22064,7 +22064,7 @@
         "urlpattern-polyfill": "^10.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.15.0"
       }
     },
     "packages/fetchache": {
@@ -22078,7 +22078,7 @@
         "@types/http-cache-semantics": "4.2.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.15.0"
       }
     },
     "packages/node-fetch": {
@@ -22096,7 +22096,7 @@
         "pem": "^1.14.8"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.15.0"
       }
     },
     "packages/promise-helpers": {
@@ -22107,7 +22107,7 @@
         "tslib": "^2.6.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=22.15.0"
       }
     },
     "packages/server": {
@@ -22136,7 +22136,7 @@
         "react-dom": "19.2.8"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.15.0"
       }
     },
     "packages/server-plugin-cookies": {
@@ -22151,7 +22151,7 @@
         "@whatwg-node/server": "^0.11.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.15.0"
       },
       "peerDependencies": {
         "@whatwg-node/server": "^0.10.0 || ^0.11.0"

--- a/packages/cookie-store/package.json
+++ b/packages/cookie-store/package.json
@@ -11,7 +11,7 @@
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.15.0"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/disposablestack/package.json
+++ b/packages/disposablestack/package.json
@@ -11,7 +11,7 @@
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.15.0"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -11,7 +11,7 @@
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.15.0"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -10,7 +10,7 @@
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.15.0"
   },
   "main": "dist/node-ponyfill.js",
   "browser": "dist/global-ponyfill.js",

--- a/packages/fetchache/package.json
+++ b/packages/fetchache/package.json
@@ -11,7 +11,7 @@
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.15.0"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/node-fetch/package.json
+++ b/packages/node-fetch/package.json
@@ -11,7 +11,7 @@
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.15.0"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/node-fetch/src/fetchCurl.ts
+++ b/packages/node-fetch/src/fetchCurl.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { PassThrough, Readable } from 'node:stream';
-import tls, { rootCertificates } from 'node:tls';
+import tls from 'node:tls';
 import { createDeferredPromise } from '@whatwg-node/promise-helpers';
 import { PonyfillRequest } from './Request.js';
 import { PonyfillResponse } from './Response.js';
@@ -23,15 +23,7 @@ export function fetchCurl<TResponseJSON = any, TRequestJSON = any>(
 
   // Prefer Node's current default CA store (includes setDefaultCACertificates and
   // NODE_EXTRA_CA_CERTS loaded at process start).
-  // tls.getCACertificates() exists since Node.js 22.15 / 23.10. Until engines bump
-  // past that (currently >=18), keep the NODE_EXTRA_CA_CERTS / rootCertificates fallback.
-  if (typeof tls.getCACertificates === 'function') {
-    curlHandle.setOpt('CAINFO_BLOB', tls.getCACertificates('default').join('\n'));
-  } else if (process.env.NODE_EXTRA_CA_CERTS) {
-    curlHandle.setOpt('CAINFO', process.env.NODE_EXTRA_CA_CERTS);
-  } else {
-    curlHandle.setOpt('CAINFO_BLOB', rootCertificates.join('\n'));
-  }
+  curlHandle.setOpt('CAINFO_BLOB', tls.getCACertificates('default').join('\n'));
 
   curlHandle.enable(CurlFeature.StreamResponse);
 

--- a/packages/node-fetch/src/fetchCurl.ts
+++ b/packages/node-fetch/src/fetchCurl.ts
@@ -21,8 +21,9 @@ export function fetchCurl<TResponseJSON = any, TRequestJSON = any>(
     curlHandle.setOpt('SSL_VERIFYPEER', false);
   }
 
-  // Prefer Node's current default CA store (includes setDefaultCACertificates and
-  // NODE_EXTRA_CA_CERTS loaded at process start).
+  // Prefer Node's current default CA store (NODE_EXTRA_CA_CERTS loaded at process
+  // start, and any CAs installed via tls.setDefaultCACertificates on Node.js
+  // 22.19+ / 24.5+ where that API exists).
   curlHandle.setOpt('CAINFO_BLOB', tls.getCACertificates('default').join('\n'));
 
   curlHandle.enable(CurlFeature.StreamResponse);

--- a/packages/promise-helpers/package.json
+++ b/packages/promise-helpers/package.json
@@ -11,7 +11,7 @@
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=22.15.0"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/server-plugin-cookies/package.json
+++ b/packages/server-plugin-cookies/package.json
@@ -11,7 +11,7 @@
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.15.0"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.15.0"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/server/src/utils.ts
+++ b/packages/server/src/utils.ts
@@ -298,8 +298,6 @@ function safeWrite<TWritable extends Writable>(
   }
 }
 
-const isNode1x = globalThis.process?.versions?.node?.startsWith('1');
-
 export function sendNodeResponse(
   fetchResponse: Response,
   serverResponse: NodeResponse,
@@ -335,9 +333,8 @@ export function sendNodeResponse(
       fetchResponse.headers.headersInit,
     );
   } else {
-    // Avoid using `setHeaders` on Node.js 18 as it is broken with multiple headers with the same name
     // @ts-expect-error - setHeaders exist
-    if (serverResponse.setHeaders && !isNode1x) {
+    if (serverResponse.setHeaders) {
       // @ts-expect-error - writeHead bad typings
       serverResponse.setHeaders(fetchResponse.headers);
     } else {

--- a/packages/server/test/node.spec.ts
+++ b/packages/server/test/node.spec.ts
@@ -470,14 +470,6 @@ describe('Node Specific Cases', () => {
               continue;
             }
             const withBody = status !== 204 && status !== 205 && status !== 304;
-            // With status code 205, Koa hangs without a body on Node 18
-            if (
-              process.versions.node.startsWith('18.') &&
-              serverImplName === 'koa' &&
-              status === 205
-            ) {
-              continue;
-            }
             it(
               status.toString(),
               async () => {


### PR DESCRIPTION
## Summary

Drop support for **Node.js 18 and 20**. The new minimum is **Node.js 22.15**.

### Motivation

- Node 18 and 20 are **EOL** and no longer receive security updates.
- Supporting them meant keeping version-specific workarounds (broken `setHeaders` on Node 18, Koa 205 hangs, older libcurl CA wiring).
- Pinning to **22.15+** (not bare `>=22`) lets us depend on `tls.getCACertificates()`, available since Node 22.15 / 23.10, and align with the oldest still-supported LTS line (22 Maintenance), while CI already exercises 24 and 26.

### Versioning

- **0.x packages**: **minor** (breaking allowed under v0).
- **1.x packages** (`@whatwg-node/promise-helpers`, `@whatwg-node/server-plugin-cookies`): **major**, because dropping supported Node versions is a breaking `engines` change for SemVer `>=1.0.0` consumers.

### Changes

- **`engines.node` → `>=22.15.0`** on all published packages (`server`, `fetch`, `node-fetch`, `events`, `cookie-store`, `server-plugin-cookies`, `disposablestack`, `fetchache`, `promise-helpers`).
- **CI**: unit matrix `[18, 20, 24, 26]` → `[22, 24, 26]`.
- **e2e**: AWS Lambda `nodejs20.x` → `nodejs22.x`; Azure Function esbuild target `node20` → `node22`.
- **`@whatwg-node/server`**: remove `isNode1x` / Node 18 `setHeaders` workaround; always use `setHeaders` when present.
- **`@whatwg-node/server` tests**: remove Koa status-205 skip that only applied on Node 18.
- **`@whatwg-node/node-fetch`**: libcurl always uses `tls.getCACertificates('default')`; drop `NODE_EXTRA_CA_CERTS` / `rootCertificates` fallback for older engines.
- **Unchanged on purpose**: fetch/node-fetch ponyfill stack, `urlpattern-polyfill` (native `URLPattern` is not on Node 22), `AbortSignal.any` leak ponyfill, and other non-18/20-specific gates.

### Migration

Upgrade the runtime to **Node.js 22.15+** (or 24 / 26) before installing this release.

## Test plan

- [ ] CI unit jobs pass on Node 22, 24, and 26
- [ ] Changeset lists every published package that bumped `engines`, with majors for 1.x packages
- [ ] Libcurl / TLS tests still honor the default CA store (including certs from `setDefaultCACertificates` where available)