### PR TITLE
[promise-helpers] remove deprecated `mapMaybePromise`

### DIFF
--- a/.changeset/remove-map-maybe-promise.md
+++ b/.changeset/remove-map-maybe-promise.md
@@ -1,0 +1,33 @@
+---
+'@whatwg-node/promise-helpers': major
+---
+
+**Breaking Change:** Remove deprecated `mapMaybePromise` in favor of `handleMaybePromise`.
+
+`mapMaybePromise(input, onSuccess, onError?)` is gone. Use `handleMaybePromise`, which takes an **input factory** (thunk) instead of a bare value so sync throws are handled the same way as promise rejections.
+
+**Before:**
+
+```ts
+import { mapMaybePromise } from '@whatwg-node/promise-helpers'
+
+const result = mapMaybePromise(
+  maybeValue,
+  value => transform(value),
+  err => fallback(err),
+)
+```
+
+**After:**
+
+```ts
+import { handleMaybePromise } from '@whatwg-node/promise-helpers'
+
+const result = handleMaybePromise(
+  () => maybeValue,
+  value => transform(value),
+  err => fallback(err),
+)
+```
+
+`handleMaybePromise` also accepts an optional fourth `finallyFactory` argument if you need cleanup.

--- a/packages/promise-helpers/src/index.ts
+++ b/packages/promise-helpers/src/index.ts
@@ -202,27 +202,6 @@ export function fakeRejectPromise<T>(error: unknown): Promise<T> {
 }
 
 /**
- * @deprecated Use `handleMaybePromise` instead.
- */
-export function mapMaybePromise<TInput, TOutput>(
-  input: MaybePromise<TInput>,
-  onSuccess: (value: TInput) => MaybePromise<TOutput>,
-  onError?: (err: any) => MaybePromise<TOutput>,
-): MaybePromise<TOutput>;
-export function mapMaybePromise<TInput, TOutput>(
-  input: MaybePromiseLike<TInput>,
-  onSuccess: (value: TInput) => MaybePromiseLike<TOutput>,
-  onError?: (err: any) => MaybePromiseLike<TOutput>,
-): MaybePromiseLike<TOutput>;
-export function mapMaybePromise<TInput, TOutput>(
-  input: MaybePromiseLike<TInput>,
-  onSuccess: (value: TInput) => MaybePromiseLike<TOutput>,
-  onError?: (err: any) => MaybePromiseLike<TOutput>,
-): MaybePromiseLike<TOutput> {
-  return handleMaybePromise(() => input, onSuccess, onError);
-}
-
-/**
  * Given an AsyncIterable and a callback function, return an AsyncIterator
  * which produces values mapped via calling the callback function.
  */


### PR DESCRIPTION
## Description

Remove the deprecated `mapMaybePromise` in favor of `handleMaybePromise`.

### Migration

**Before:**

```ts
import { mapMaybePromise } from '@whatwg-node/promise-helpers'

const result = mapMaybePromise(
  maybeValue,
  value => transform(value),
  err => fallback(err),
)
```

**After:**

```ts
import { handleMaybePromise } from '@whatwg-node/promise-helpers'

const result = handleMaybePromise(
  () => maybeValue,
  value => transform(value),
  err => fallback(err),
)
```

`handleMaybePromise` takes an input factory (thunk) instead of a bare value so sync throws are handled the same way as promise rejections. An optional fourth `finallyFactory` argument is also available.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test plan

- [ ] Confirm `mapMaybePromise` is no longer exported from `@whatwg-node/promise-helpers`
- [ ] Existing `handleMaybePromise` tests still pass