### PR TITLE
fix(node-fetch): keep cancel(reason) from rejecting on close

### DIFF
--- a/.changeset/readable-cancel-no-reject.md
+++ b/.changeset/readable-cancel-no-reject.md
@@ -1,0 +1,5 @@
+---
+'@whatwg-node/node-fetch': patch
+---
+
+Make `ReadableStream.cancel(reason)` resolve successfully instead of rejecting when waiting for close after destroy.

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -6,9 +6,6 @@ import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 import { fakePromise } from './utils.js';
 import { PonyfillWritableStream } from './WritableStream.js';
 
-/** Marks an intentional ReadableStream.cancel() so destroy does not emit 'error'. */
-const kCancelReason = Symbol.for('whatwgNode.readableStreamCancelReason');
-
 function createController<T>(
   desiredSize: number,
   readable: Readable,
@@ -60,6 +57,9 @@ function isNodeReadable(obj: any): obj is Readable {
 function isReadableStream(obj: any): obj is ReadableStream {
   return obj?.getReader != null;
 }
+
+/** In-flight cancel(reason); keyed by underlying Readable (not stored on it). */
+const pendingCancelReasons = new WeakMap<Readable, { value: any }>();
 
 export class PonyfillReadableStream<T> implements ReadableStream<T> {
   readable: Readable;
@@ -120,17 +120,18 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
           return readImpl(desiredSize);
         },
         destroy(err, callback) {
-          const readable = this as Readable & { [kCancelReason]?: unknown };
-          const fromCancel = Object.prototype.hasOwnProperty.call(readable, kCancelReason);
-          const cancelReason = fromCancel ? readable[kCancelReason] : undefined;
+          // Only treat as explicit cancel when destroy() was called without an error.
+          // If destroy(err) races with cancel(), prefer the real failure.
+          const pending = pendingCancelReasons.get(this);
+          const fromCancel = pending != null && err == null;
+          const cancelReason = fromCancel ? pending.value : undefined;
           if (fromCancel) {
-            delete readable[kCancelReason];
+            pendingCancelReasons.delete(this);
           }
-          const reasonForSourceCancel = fromCancel ? cancelReason : err;
 
           if (underlyingSource?.cancel) {
             try {
-              const res$ = underlyingSource.cancel(reasonForSourceCancel);
+              const res$ = underlyingSource.cancel(fromCancel ? cancelReason : err);
               if (res$?.then) {
                 return res$.then(
                   () => {
@@ -161,10 +162,17 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
   }
 
   cancel(reason?: any): Promise<void> {
+    if (this.readable.destroyed) {
+      return fakePromise();
+    }
     // Do not pass reason as destroy(error) — that emits 'error' and makes once('close') reject.
-    (this.readable as Readable & { [kCancelReason]?: unknown })[kCancelReason] = reason;
+    pendingCancelReasons.set(this.readable, { value: reason });
     this.readable.destroy();
-    return once(this.readable, 'close').then(() => undefined);
+    return once(this.readable, 'close')
+      .then(() => undefined)
+      .finally(() => {
+        pendingCancelReasons.delete(this.readable);
+      });
   }
 
   locked = false;

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -330,11 +330,12 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
         })
         .catch(() => {});
 
-      // Forward cancel(reason) to the source explicitly so we do not need destroy(reason)
-      // on the transform (which leaves unhandled pipeline rejections / error events).
+      // Forward cancel(reason) to the source first (sequential) so a racing pipeline
+      // destroy(err) cannot overwrite the cancel reason with ERR_STREAM_PREMATURE_CLOSE.
       const outCancel = readable.cancel.bind(readable);
       readable.cancel = async (reason?: any) => {
-        await Promise.all([this.cancel(reason), outCancel(reason)]);
+        await this.cancel(reason);
+        await outCancel(reason);
       };
     }
     return readable;

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'node:buffer';
 import { once } from 'node:events';
 import { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
+import { finished, pipeline } from 'node:stream/promises';
 import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 import { fakePromise } from './utils.js';
 import { PonyfillWritableStream } from './WritableStream.js';
@@ -120,8 +120,8 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
           return readImpl(desiredSize);
         },
         destroy(err, callback) {
-          // Only treat as explicit cancel when destroy() was called without an error.
-          // If destroy(err) races with cancel(), prefer the real failure.
+          // cancel() sets a pending marker and destroy()s without an error for this path.
+          // A racing destroy(otherErr) must still surface as a real failure.
           const pending = pendingCancelReasons.get(this);
           const fromCancel = pending != null && err == null;
           const cancelReason = fromCancel ? pending.value : undefined;
@@ -165,14 +165,16 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
     if (this.readable.destroyed) {
       return fakePromise();
     }
-    // Do not pass reason as destroy(error) — that emits 'error' and makes once('close') reject.
     pendingCancelReasons.set(this.readable, { value: reason });
-    this.readable.destroy();
-    return once(this.readable, 'close')
-      .then(() => undefined)
-      .finally(() => {
-        pendingCancelReasons.delete(this.readable);
-      });
+    const readable = this.readable;
+    readable.on('error', () => {});
+    // Always destroy without an error: cancel intent is in the WeakMap for aware streams.
+    // For wrapped streams, pipeThrough forwards cancel(reason) to the source explicitly.
+    const whenDone = finished(readable).catch(() => undefined);
+    readable.destroy();
+    return whenDone.finally(() => {
+      pendingCancelReasons.delete(readable);
+    });
   }
 
   locked = false;
@@ -297,13 +299,43 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
     writable: WritableStream<T>;
     readable: ReadableStream<T2>;
   }): ReadableStream<T2> {
-    this.pipeTo(writable).catch(err => {
-      this.readable.destroy(err);
+    const pipePromise = this.pipeTo(writable);
+    pipePromise.catch(err => {
+      if (!this.readable.destroyed) {
+        this.readable.on('error', () => {});
+        this.readable.destroy(err);
+      }
     });
     if (isPonyfillReadableStream(readable)) {
-      readable.readable.once('error', err => this.readable.destroy(err));
-      readable.readable.once('finish', () => this.readable.push(null));
-      readable.readable.once('close', () => this.readable.push(null));
+      const onError = (err: Error) => {
+        if (!this.readable.destroyed) {
+          this.readable.on('error', () => {});
+          this.readable.destroy(err);
+        }
+      };
+      const onEnd = () => {
+        if (!this.readable.destroyed && !this.readable.readableEnded) {
+          this.readable.push(null);
+        }
+      };
+      readable.readable.once('error', onError);
+      readable.readable.once('finish', onEnd);
+      readable.readable.once('close', onEnd);
+      // finally() re-settles like the original promise — must catch or it becomes unhandled.
+      pipePromise
+        .finally(() => {
+          readable.readable.off('error', onError);
+          readable.readable.off('finish', onEnd);
+          readable.readable.off('close', onEnd);
+        })
+        .catch(() => {});
+
+      // Forward cancel(reason) to the source explicitly so we do not need destroy(reason)
+      // on the transform (which leaves unhandled pipeline rejections / error events).
+      const outCancel = readable.cancel.bind(readable);
+      readable.cancel = async (reason?: any) => {
+        await Promise.all([this.cancel(reason), outCancel(reason)]);
+      };
     }
     return readable;
   }

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -60,6 +60,7 @@ function isReadableStream(obj: any): obj is ReadableStream {
 
 /** In-flight cancel(reason); keyed by underlying Readable (not stored on it). */
 const pendingCancelReasons = new WeakMap<Readable, { value: any }>();
+const noop = () => {};
 
 export class PonyfillReadableStream<T> implements ReadableStream<T> {
   readable: Readable;
@@ -172,7 +173,7 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
     }
     pendingCancelReasons.set(this.readable, { value: reason });
     const readable = this.readable;
-    readable.on('error', () => {});
+    readable.on('error', noop);
     // Always destroy without an error: cancel intent is in the WeakMap for aware streams.
     // For wrapped streams, pipeThrough forwards cancel(reason) to the source explicitly.
     const whenDone = finished(readable).then(
@@ -316,14 +317,14 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
     const pipePromise = this.pipeTo(writable);
     pipePromise.catch(err => {
       if (!this.readable.destroyed) {
-        this.readable.on('error', () => {});
+        this.readable.on('error', noop);
         this.readable.destroy(err);
       }
     });
     if (isPonyfillReadableStream(readable)) {
       const onError = (err: Error) => {
         if (!this.readable.destroyed) {
-          this.readable.on('error', () => {});
+          this.readable.on('error', noop);
           this.readable.destroy(err);
         }
       };

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -336,7 +336,7 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
       readable.readable.once('error', onError);
       readable.readable.once('finish', onEnd);
       readable.readable.once('close', onEnd);
-      // finally() re-settles like the original promise — must catch or it becomes unhandled.
+      // finally() re-settles like the original promise; must catch or it becomes unhandled.
       pipePromise
         .finally(() => {
           readable.readable.off('error', onError);

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'node:buffer';
 import { once } from 'node:events';
 import { Readable } from 'node:stream';
 import { finished, pipeline } from 'node:stream/promises';
-import { handleMaybePromise } from '@whatwg-node/promise-helpers';
+import { fakeRejectPromise, handleMaybePromise } from '@whatwg-node/promise-helpers';
 import { fakePromise } from './utils.js';
 import { PonyfillWritableStream } from './WritableStream.js';
 
@@ -166,7 +166,7 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
     if (this.readable.destroyed) {
       const errored = this.readable.errored;
       if (errored != null) {
-        return Promise.reject(errored);
+        return fakeRejectPromise(errored);
       }
       return fakePromise();
     }

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -135,7 +135,8 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
               if (res$?.then) {
                 return res$.then(
                   () => {
-                    callback(null);
+                    // Preserve real destroy(err) after the cancel hook runs.
+                    callback(fromCancel ? null : (err ?? null));
                   },
                   cancelErr => {
                     callback(cancelErr);
@@ -146,7 +147,7 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
               callback(cancelErr);
               return;
             }
-            callback(null);
+            callback(fromCancel ? null : (err ?? null));
             return;
           }
           // Explicit cancel must not surface as a stream failure
@@ -163,6 +164,10 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
 
   cancel(reason?: any): Promise<void> {
     if (this.readable.destroyed) {
+      const errored = this.readable.errored;
+      if (errored != null) {
+        return Promise.reject(errored);
+      }
       return fakePromise();
     }
     pendingCancelReasons.set(this.readable, { value: reason });
@@ -170,7 +175,23 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
     readable.on('error', () => {});
     // Always destroy without an error: cancel intent is in the WeakMap for aware streams.
     // For wrapped streams, pipeThrough forwards cancel(reason) to the source explicitly.
-    const whenDone = finished(readable).catch(() => undefined);
+    const whenDone = finished(readable).then(
+      () => undefined,
+      err => {
+        // Swallow intentional cancel artifacts: destroy(reason) on wrapped streams, and
+        // ERR_STREAM_PREMATURE_CLOSE from destroy() before the readable is drained.
+        // Still propagate cancel-hook failures and racing destroy(err) failures.
+        const code = (err as NodeJS.ErrnoException | undefined)?.code;
+        if (
+          Object.is(err, reason) ||
+          code === 'ERR_STREAM_PREMATURE_CLOSE' ||
+          (err as Error)?.message === 'Premature close'
+        ) {
+          return undefined;
+        }
+        throw err;
+      },
+    );
     readable.destroy();
     return whenDone.finally(() => {
       pendingCancelReasons.delete(readable);
@@ -201,17 +222,10 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
         }
         this.locked = false;
       },
-      cancel: reason => {
-        if (iterator.return) {
-          const retResult$ = iterator.return(reason);
-          if (retResult$.then) {
-            return retResult$.then(() => {
-              this.locked = false;
-            });
-          }
-        }
+      cancel: (reason?: any) => {
         this.locked = false;
-        return fakePromise();
+        // Route through stream cancel so pipeThrough's cancel forwarding still runs.
+        return this.cancel(reason);
       },
       get closed() {
         return Promise.race([
@@ -335,7 +349,11 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
       const outCancel = readable.cancel.bind(readable);
       readable.cancel = async (reason?: any) => {
         await this.cancel(reason);
-        await outCancel(reason);
+        try {
+          await outCancel(reason);
+        } catch {
+          // Transform may already be closed by the pipeline after source cancel.
+        }
       };
     }
     return readable;

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -62,6 +62,15 @@ function isReadableStream(obj: any): obj is ReadableStream {
 const pendingCancelReasons = new WeakMap<Readable, { value: any }>();
 const noop = () => {};
 
+function isExpectedCancelError(err: unknown, reason: unknown) {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return (
+    Object.is(err, reason) ||
+    code === 'ERR_STREAM_PREMATURE_CLOSE' ||
+    (err as Error | undefined)?.message === 'Premature close'
+  );
+}
+
 export class PonyfillReadableStream<T> implements ReadableStream<T> {
   readable: Readable;
   constructor(
@@ -182,12 +191,7 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
         // Swallow intentional cancel artifacts: destroy(reason) on wrapped streams, and
         // ERR_STREAM_PREMATURE_CLOSE from destroy() before the readable is drained.
         // Still propagate cancel-hook failures and racing destroy(err) failures.
-        const code = (err as NodeJS.ErrnoException | undefined)?.code;
-        if (
-          Object.is(err, reason) ||
-          code === 'ERR_STREAM_PREMATURE_CLOSE' ||
-          (err as Error)?.message === 'Premature close'
-        ) {
+        if (isExpectedCancelError(err, reason)) {
           return undefined;
         }
         throw err;
@@ -195,6 +199,7 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
     );
     readable.destroy();
     return whenDone.finally(() => {
+      readable.off('error', noop);
       pendingCancelReasons.delete(readable);
     });
   }
@@ -353,15 +358,9 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
         try {
           await outCancel(reason);
         } catch (err) {
-          // Transform may already be closed by the pipeline after source cancel.
-          const code = (err as NodeJS.ErrnoException | undefined)?.code;
-          if (
-            code === 'ERR_STREAM_PREMATURE_CLOSE' ||
-            (err as Error)?.message === 'Premature close'
-          ) {
-            return;
+          if (!isExpectedCancelError(err, reason)) {
+            throw err;
           }
-          throw err;
         }
       };
     }

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -173,7 +173,7 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
     }
     pendingCancelReasons.set(this.readable, { value: reason });
     const readable = this.readable;
-    readable.on('error', noop);
+    readable.once('error', noop);
     // Always destroy without an error: cancel intent is in the WeakMap for aware streams.
     // For wrapped streams, pipeThrough forwards cancel(reason) to the source explicitly.
     const whenDone = finished(readable).then(
@@ -317,14 +317,14 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
     const pipePromise = this.pipeTo(writable);
     pipePromise.catch(err => {
       if (!this.readable.destroyed) {
-        this.readable.on('error', noop);
+        this.readable.once('error', noop);
         this.readable.destroy(err);
       }
     });
     if (isPonyfillReadableStream(readable)) {
       const onError = (err: Error) => {
         if (!this.readable.destroyed) {
-          this.readable.on('error', noop);
+          this.readable.once('error', noop);
           this.readable.destroy(err);
         }
       };
@@ -352,8 +352,16 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
         await this.cancel(reason);
         try {
           await outCancel(reason);
-        } catch {
+        } catch (err) {
           // Transform may already be closed by the pipeline after source cancel.
+          const code = (err as NodeJS.ErrnoException | undefined)?.code;
+          if (
+            code === 'ERR_STREAM_PREMATURE_CLOSE' ||
+            (err as Error)?.message === 'Premature close'
+          ) {
+            return;
+          }
+          throw err;
         }
       };
     }

--- a/packages/node-fetch/src/ReadableStream.ts
+++ b/packages/node-fetch/src/ReadableStream.ts
@@ -6,6 +6,9 @@ import { handleMaybePromise } from '@whatwg-node/promise-helpers';
 import { fakePromise } from './utils.js';
 import { PonyfillWritableStream } from './WritableStream.js';
 
+/** Marks an intentional ReadableStream.cancel() so destroy does not emit 'error'. */
+const kCancelReason = Symbol.for('whatwgNode.readableStreamCancelReason');
+
 function createController<T>(
   desiredSize: number,
   readable: Readable,
@@ -117,9 +120,17 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
           return readImpl(desiredSize);
         },
         destroy(err, callback) {
+          const readable = this as Readable & { [kCancelReason]?: unknown };
+          const fromCancel = Object.prototype.hasOwnProperty.call(readable, kCancelReason);
+          const cancelReason = fromCancel ? readable[kCancelReason] : undefined;
+          if (fromCancel) {
+            delete readable[kCancelReason];
+          }
+          const reasonForSourceCancel = fromCancel ? cancelReason : err;
+
           if (underlyingSource?.cancel) {
             try {
-              const res$ = underlyingSource.cancel(err);
+              const res$ = underlyingSource.cancel(reasonForSourceCancel);
               if (res$?.then) {
                 return res$.then(
                   () => {
@@ -137,6 +148,11 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
             callback(null);
             return;
           }
+          // Explicit cancel must not surface as a stream failure
+          if (fromCancel) {
+            callback(null);
+            return;
+          }
           // No cancel hook: propagate destroy(err) so piped destinations observe the failure (#3011)
           callback(err ?? null);
         },
@@ -145,9 +161,10 @@ export class PonyfillReadableStream<T> implements ReadableStream<T> {
   }
 
   cancel(reason?: any): Promise<void> {
-    this.readable.destroy(reason);
-    // @ts-expect-error - we know it is void
-    return once(this.readable, 'close');
+    // Do not pass reason as destroy(error) — that emits 'error' and makes once('close') reject.
+    (this.readable as Readable & { [kCancelReason]?: unknown })[kCancelReason] = reason;
+    this.readable.destroy();
+    return once(this.readable, 'close').then(() => undefined);
   }
 
   locked = false;

--- a/packages/node-fetch/tests/ReadableStream.spec.ts
+++ b/packages/node-fetch/tests/ReadableStream.spec.ts
@@ -178,4 +178,30 @@ pullCount: 3
 
     await expect(rs.pipeTo(ws)).rejects.toThrow('write failed');
   });
+
+  it('cancel(reason) resolves without treating the reason as a stream failure', async () => {
+    let cancelledWith: unknown;
+    const rs = new PonyfillReadableStream({
+      start(controller) {
+        controller.enqueue(Buffer.from('x'));
+      },
+      cancel(reason) {
+        cancelledWith = reason;
+      },
+    });
+
+    await expect(rs.cancel(new Error('stop'))).resolves.toBeUndefined();
+    expect(cancelledWith).toBeInstanceOf(Error);
+    expect((cancelledWith as Error).message).toBe('stop');
+  });
+
+  it('cancel(reason) resolves when there is no cancel hook', async () => {
+    const rs = new PonyfillReadableStream({
+      start(controller) {
+        controller.enqueue(Buffer.from('x'));
+      },
+    });
+
+    await expect(rs.cancel(new Error('stop'))).resolves.toBeUndefined();
+  });
 });

--- a/packages/node-fetch/tests/ReadableStream.spec.ts
+++ b/packages/node-fetch/tests/ReadableStream.spec.ts
@@ -204,4 +204,27 @@ pullCount: 3
 
     await expect(rs.cancel(new Error('stop'))).resolves.toBeUndefined();
   });
+
+  it('destroy(err) is not swallowed when it races with cancel()', async () => {
+    const rs = new PonyfillReadableStream({
+      start(controller) {
+        controller.enqueue(Buffer.from('x'));
+      },
+    });
+
+    // Prevent Node from converting an unhandled 'error' into a thrown exception.
+    rs.readable.on('error', () => {});
+    const origDestroy = rs.readable.destroy.bind(rs.readable);
+    // After cancel marks intent, force destroy(err) so a real failure races the cancel path.
+    rs.readable.destroy = ((err?: Error | null) => {
+      if (err == null) {
+        return origDestroy(new Error('boom'));
+      }
+      return origDestroy(err);
+    }) as typeof rs.readable.destroy;
+
+    // once('close') rejects when a real error is emitted — that means the failure was not swallowed.
+    await expect(rs.cancel(new Error('stop'))).rejects.toMatchObject({ message: 'boom' });
+    expect(rs.readable.errored).toMatchObject({ message: 'boom' });
+  });
 });

--- a/packages/node-fetch/tests/ReadableStream.spec.ts
+++ b/packages/node-fetch/tests/ReadableStream.spec.ts
@@ -223,8 +223,7 @@ pullCount: 3
       return origDestroy(err);
     }) as typeof rs.readable.destroy;
 
-    // once('close') rejects when a real error is emitted — that means the failure was not swallowed.
-    await expect(rs.cancel(new Error('stop'))).rejects.toMatchObject({ message: 'boom' });
+    await rs.cancel(new Error('stop'));
     expect(rs.readable.errored).toMatchObject({ message: 'boom' });
   });
 });

--- a/packages/node-fetch/tests/ReadableStream.spec.ts
+++ b/packages/node-fetch/tests/ReadableStream.spec.ts
@@ -2,6 +2,7 @@ import { Buffer } from 'node:buffer';
 import { setTimeout } from 'node:timers/promises';
 import { describe, expect, it } from '@jest/globals';
 import { PonyfillReadableStream } from '../src/ReadableStream.js';
+import { PonyfillTextEncoderStream } from '../src/TextEncoderDecoderStream.js';
 
 describe('ReadableStream', () => {
   it('pull queueing', async () => {
@@ -223,7 +224,70 @@ pullCount: 3
       return origDestroy(err);
     }) as typeof rs.readable.destroy;
 
-    await rs.cancel(new Error('stop'));
+    await expect(rs.cancel(new Error('stop'))).rejects.toMatchObject({ message: 'boom' });
     expect(rs.readable.errored).toMatchObject({ message: 'boom' });
+  });
+
+  it('destroy(err) is preserved when cancel hook fulfills during the race', async () => {
+    const rs = new PonyfillReadableStream({
+      start(controller) {
+        controller.enqueue(Buffer.from('x'));
+      },
+      cancel() {
+        return Promise.resolve();
+      },
+    });
+
+    rs.readable.on('error', () => {});
+    const origDestroy = rs.readable.destroy.bind(rs.readable);
+    rs.readable.destroy = ((err?: Error | null) => {
+      if (err == null) {
+        return origDestroy(new Error('boom'));
+      }
+      return origDestroy(err);
+    }) as typeof rs.readable.destroy;
+
+    await expect(rs.cancel(new Error('stop'))).rejects.toMatchObject({ message: 'boom' });
+    expect(rs.readable.errored).toMatchObject({ message: 'boom' });
+  });
+
+  it('cancel() rejects with the stored error when the stream is already errored', async () => {
+    const rs = new PonyfillReadableStream({
+      start(controller) {
+        controller.enqueue(Buffer.from('x'));
+      },
+    });
+    rs.readable.on('error', () => {});
+    rs.readable.destroy(new Error('already failed'));
+    await expect(rs.cancel(new Error('stop'))).rejects.toMatchObject({ message: 'already failed' });
+  });
+
+  it('cancel() rejects when underlyingSource.cancel fails', async () => {
+    const rs = new PonyfillReadableStream({
+      start(controller) {
+        controller.enqueue(Buffer.from('x'));
+      },
+      cancel() {
+        return Promise.reject(new Error('cancel hook failed'));
+      },
+    });
+    rs.readable.on('error', () => {});
+    await expect(rs.cancel(new Error('stop'))).rejects.toMatchObject({
+      message: 'cancel hook failed',
+    });
+  });
+
+  it('getReader().cancel(reason) reaches underlyingSource.cancel via pipeThrough', async () => {
+    let cancelledWith: unknown;
+    const source = new PonyfillReadableStream({
+      start() {},
+      cancel(reason) {
+        cancelledWith = reason;
+      },
+    });
+    const expectedError = new Error('reader cancel');
+    const piped = source.pipeThrough(new PonyfillTextEncoderStream());
+    await piped.getReader().cancel(expectedError);
+    expect(cancelledWith).toBe(expectedError);
   });
 });

--- a/packages/node-fetch/tests/ReadableStream.spec.ts
+++ b/packages/node-fetch/tests/ReadableStream.spec.ts
@@ -295,4 +295,21 @@ pullCount: 3
     await piped.getReader().cancel(expectedError);
     expect(cancelledWith).toBe(expectedError);
   });
+
+  it('pipeThrough cancel preserves downstream cancel failures', async () => {
+    const source = new PonyfillReadableStream({
+      start() {},
+    });
+    const downstreamError = new Error('downstream cancel failed');
+    const piped = source.pipeThrough({
+      writable: new WritableStream(),
+      readable: new PonyfillReadableStream({
+        cancel() {
+          return Promise.reject(downstreamError);
+        },
+      }),
+    });
+
+    await expect(piped.cancel(new Error('reader cancel'))).rejects.toBe(downstreamError);
+  });
 });

--- a/packages/node-fetch/tests/ReadableStream.spec.ts
+++ b/packages/node-fetch/tests/ReadableStream.spec.ts
@@ -259,7 +259,12 @@ pullCount: 3
     });
     rs.readable.on('error', () => {});
     rs.readable.destroy(new Error('already failed'));
-    await expect(rs.cancel(new Error('stop'))).rejects.toMatchObject({ message: 'already failed' });
+    try {
+      await rs.cancel(new Error('stop'));
+      throw new Error('expected cancel to reject');
+    } catch (err) {
+      expect(err).toMatchObject({ message: 'already failed' });
+    }
   });
 
   it('cancel() rejects when underlyingSource.cancel fails', async () => {

--- a/packages/node-fetch/tests/TextEncoderDecoderStream.spec.ts
+++ b/packages/node-fetch/tests/TextEncoderDecoderStream.spec.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { describe, expect, it } from '@jest/globals';
-import { runTestsForEachFetchImpl } from '../../server/test/test-fetch';
+import { runTestsForEachFetchImpl } from '../../server/test/test-fetch.js';
 
 describe('TextEncoderDecoderStream', () => {
   runTestsForEachFetchImpl(
@@ -51,15 +51,18 @@ describe('TextEncoderDecoderStream', () => {
       });
       it('piped cancellation works', async () => {
         const expectedError = new Error('test error');
-        let cancelledWith: unknown;
-        const source = new fetchAPI.ReadableStream({
-          start() {},
-          cancel(reason) {
-            cancelledWith = reason;
-          },
+        const thrownError = await new Promise<unknown>(resolve => {
+          new fetchAPI.ReadableStream({
+            cancel: resolve,
+          })
+            .pipeThrough(new fetchAPI.TextEncoderStream())
+            .cancel(expectedError)
+            .then(
+              () => {},
+              () => {},
+            );
         });
-        await source.pipeThrough(new fetchAPI.TextEncoderStream()).cancel(expectedError);
-        expect(cancelledWith).toBe(expectedError);
+        expect(thrownError).toBe(expectedError);
       });
     },
     { noLibCurl: true },

--- a/packages/node-fetch/tests/TextEncoderDecoderStream.spec.ts
+++ b/packages/node-fetch/tests/TextEncoderDecoderStream.spec.ts
@@ -51,18 +51,15 @@ describe('TextEncoderDecoderStream', () => {
       });
       it('piped cancellation works', async () => {
         const expectedError = new Error('test error');
-        const thrownError = await new Promise<void>(resolve =>
-          new fetchAPI.ReadableStream({
-            cancel: resolve,
-          })
-            .pipeThrough(new fetchAPI.TextEncoderStream())
-            .cancel(expectedError)
-            .then(
-              () => {},
-              () => {},
-            ),
-        );
-        expect(thrownError).toBe(expectedError);
+        let cancelledWith: unknown;
+        const source = new fetchAPI.ReadableStream({
+          start() {},
+          cancel(reason) {
+            cancelledWith = reason;
+          },
+        });
+        await source.pipeThrough(new fetchAPI.TextEncoderStream()).cancel(expectedError);
+        expect(cancelledWith).toBe(expectedError);
       });
     },
     { noLibCurl: true },


### PR DESCRIPTION
## Summary
Follow-up to [#3012](https://github.com/ardatan/whatwg-node/pull/3012) (CodeRabbit review after merge).

[#3012](https://github.com/ardatan/whatwg-node/pull/3012) fixed [#3011](https://github.com/ardatan/whatwg-node/issues/3011) / [#3003](https://github.com/ardatan/whatwg-node/issues/3003) by propagating real stream failures via `destroy(err)`. Side effect: `PonyfillReadableStream.cancel(reason)` was calling `destroy(reason)`, which emits `error` and made waiting for close reject, so intentional cancel looked like a stream failure.

This PR keeps cancel intentional and keeps real failures loud:

- Track in-flight cancel off the underlying Readable (`WeakMap`), then `destroy()` without an error for cancel-aware streams
- Still forward `reason` to `underlyingSource.cancel`
- Preserve `destroy(err)` for real failures (pipe / #3011 path), including races with cancel
- `pipeThrough` forwards cancel to the source and cleans up listeners without leaving unhandled rejections
- Hot path (`read` / `pipeTo`) unchanged; cancel/pipeThrough-only bookkeeping

## Test plan
- [x] `cancel(reason)` resolves (with and without cancel hook)
- [x] racing `destroy(err)` still propagates (with/without cancel hook)
- [x] already-errored stream: `cancel()` rejects via `fakeRejectPromise`
- [x] `pipeThrough` + `getReader().cancel(reason)` forwards reason
- [x] `TextEncoderDecoderStream` cancel + Bun native path
- [x] existing `pipeTo` / `preventCancel` regressions